### PR TITLE
feat: Memos, MemoSet, Tags API PLANA-76 PLANA-77

### DIFF
--- a/calendars/urls.py
+++ b/calendars/urls.py
@@ -5,11 +5,11 @@ from .views import (
     CalendarDetailView,
     CalendarListView,
     ScheduleCopyView,
+    ScheduleCreateView,
+    ScheduleDeleteView,
     ScheduleDetailView,
     ScheduleListView,
     ScheduleSearchView,
-    ScheduleCreateView,
-    ScheduleDeleteView,
     ScheduleUpdateView,
 )
 
@@ -23,9 +23,25 @@ urlpatterns = [
     path("", CalendarListView.as_view(), name="calendar-list"),
     path("schedule", ScheduleCreateView.as_view(), name="schedule-create"),
     path("schedule", ScheduleListView.as_view(), name="schedule-list"),
-    path("schedule/<int:schedule_id>", ScheduleDetailView.as_view(), name="schedule-detail"),
-    path("schedule/<int:schedule_id>", ScheduleDeleteView.as_view(), name="schedule-delete"),
-    path("schedule/<int:schedule_id>", ScheduleUpdateView.as_view(), name="schedule-update"),
-    path("schedule/<int:schedule_id>/copy", ScheduleCopyView.as_view(), name="schedule-copy"),
+    path(
+        "schedule/<int:schedule_id>",
+        ScheduleDetailView.as_view(),
+        name="schedule-detail",
+    ),
+    path(
+        "schedule/<int:schedule_id>",
+        ScheduleDeleteView.as_view(),
+        name="schedule-delete",
+    ),
+    path(
+        "schedule/<int:schedule_id>",
+        ScheduleUpdateView.as_view(),
+        name="schedule-update",
+    ),
+    path(
+        "schedule/<int:schedule_id>/copy",
+        ScheduleCopyView.as_view(),
+        name="schedule-copy",
+    ),
     path("schedule/search", ScheduleSearchView.as_view(), name="schedule-search"),
 ]

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -1,4 +1,4 @@
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
@@ -8,14 +8,14 @@ from .serializers import (
     CalendarCreateSerializer,
     CalendarDetailSerializer,
     CalendarListSerializer,
+    ScheduleCopySerializer,
     ScheduleCreateSerializer,
     ScheduleDetailSerializer,
     ScheduleListQuerySerializer,
-    ScheduleSearchQuerySerializer,
-    ScheduleUpdateSerializer,
-    ScheduleCopySerializer,
-    ScheduleSearchSerializer,
     ScheduleListSerializer,
+    ScheduleSearchQuerySerializer,
+    ScheduleSearchSerializer,
+    ScheduleUpdateSerializer,
 )
 
 
@@ -106,7 +106,8 @@ class ScheduleCopyView(APIView):
     def post(self, request, schedule_id):
         # Placeholder implementation
         return Response(
-            {"message": f"Copied schedule {schedule_id}"}, status=status.HTTP_201_CREATED
+            {"message": f"Copied schedule {schedule_id}"},
+            status=status.HTTP_201_CREATED,
         )
 
 
@@ -140,15 +141,21 @@ class ScheduleSearchView(APIView):
         description="문자열 기반 검색을 수행합니다. Calendar 필터링 옵션을 할 수 있습니다. Tag 옵션을 사용하여 지정된 태그만을 필터링 할 수 있습니다.",
         parameters=[
             # ScheduleSearchQuerySerializer, # TODO - Query Param Serializer
-            OpenApiParameter(name="query", description="검색 문자열", required=True, type=str),
-            OpenApiParameter(name="tag", description="필터링할 태그", required=False, type=str),
+            OpenApiParameter(
+                name="query", description="검색 문자열", required=True, type=str
+            ),
+            OpenApiParameter(
+                name="tag", description="필터링할 태그", required=False, type=str
+            ),
         ],
         responses={200: ScheduleSearchSerializer},
         tags=["Schedules"],
     )
     def get(self, request):
         # Placeholder implementation
-        return Response({"message": "Schedule search results"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": "Schedule search results"}, status=status.HTTP_200_OK
+        )
 
 
 class ScheduleDetailView(APIView):
@@ -188,4 +195,6 @@ class ScheduleUpdateView(APIView):
     )
     def put(self, request, schedule_id):
         # Placeholder implementation
-        return Response({"message": f"Updated schedule {schedule_id}"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Updated schedule {schedule_id}"}, status=status.HTTP_200_OK
+        )

--- a/core/urls.py
+++ b/core/urls.py
@@ -28,6 +28,7 @@ app_urls = [
     path("api/v1/calendars/", include("calendars.urls")),
     path("api/v1/todos/", include("todos.urls")),
     path("api/v1/memos/", include("memos.urls")),
+    path("api/v1/tags/", include("tags.urls")),
 ]
 
 schema_urls = [

--- a/core/urls.py
+++ b/core/urls.py
@@ -23,12 +23,14 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-urlpatterns = [
-    path("admin/", admin.site.urls),
+app_urls = [
     # path("api/v1/users/", include("users.urls")),
     path("api/v1/calendars/", include("calendars.urls")),
     path("api/v1/todos/", include("todos.urls")),
-    ### API documents
+    path("api/v1/memos/", include("memos.urls")),
+]
+
+schema_urls = [
     path("api/v1/schema", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/v1/schema/swagger-ui/",
@@ -41,3 +43,7 @@ urlpatterns = [
         name="redoc",
     ),
 ]
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+] + app_urls + schema_urls

--- a/core/urls.py
+++ b/core/urls.py
@@ -45,6 +45,10 @@ schema_urls = [
     ),
 ]
 
-urlpatterns = [
-    path("admin/", admin.site.urls),
-] + app_urls + schema_urls
+urlpatterns = (
+    [
+        path("admin/", admin.site.urls),
+    ]
+    + app_urls
+    + schema_urls
+)

--- a/memos/serializers.py
+++ b/memos/serializers.py
@@ -1,0 +1,41 @@
+from rest_framework import serializers as s
+
+
+class MemoCreateSerializer(s.Serializer):
+    pass
+
+
+class MemoListSerializer(s.Serializer):
+    pass
+
+
+class MemoDetailSerializer(s.Serializer):
+    pass
+
+
+class MemoUpdateSerializer(s.Serializer):
+    pass
+
+
+class MemoDeleteSerializer(s.Serializer):
+    pass
+
+
+class MemoSetCreateSerializer(s.Serializer):
+    pass
+
+
+class MemoSetListSerializer(s.Serializer):
+    pass
+
+
+class MemoSetDetailSerializer(s.Serializer):
+    pass
+
+
+class MemoSetUpdateSerializer(s.Serializer):
+    pass
+
+
+class MemoSetDeleteSerializer(s.Serializer):
+    pass

--- a/memos/urls.py
+++ b/memos/urls.py
@@ -1,0 +1,29 @@
+from django.urls import path
+
+from .views import (
+    MemoCreateView,
+    MemoListView,
+    MemoDetailView,
+    MemoUpdateView,
+    MemoDeleteView,
+    MemoSetCreateView,
+    MemoSetListView,
+    MemoSetDetailView,
+    MemoSetUpdateView,
+    MemoSetDeleteView,
+)
+
+urlpatterns = [
+    ### Memo
+    path("", MemoCreateView.as_view(), name="memo-create"),
+    path("", MemoListView.as_view(), name="memo-list"),
+    path("<int:memo_id>", MemoDetailView.as_view(), name="memo-detail"),
+    path("<int:memo_id>", MemoUpdateView.as_view(), name="memo-update"),
+    path("<int:memo_id>", MemoDeleteView.as_view(), name="memo-delete"),
+    ### Memoset
+    path("set", MemoSetCreateView.as_view(), name="memoset-create"),
+    path("set", MemoSetListView.as_view(), name="memoset-list"),
+    path("set/<int:set_id>", MemoSetDetailView.as_view(), name="memoset-deltail"),
+    path("set/<int:set_id>", MemoSetUpdateView.as_view(), name="memoset-update"),
+    path("set/<int:set_id>", MemoSetDeleteView.as_view(), name="memoset-delete"),
+]

--- a/memos/urls.py
+++ b/memos/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     ### Memoset
     path("set", MemoSetCreateView.as_view(), name="memoset-create"),
     path("set", MemoSetListView.as_view(), name="memoset-list"),
-    path("set/<int:set_id>", MemoSetDetailView.as_view(), name="memoset-deltail"),
+    path("set/<int:set_id>", MemoSetDetailView.as_view(), name="memoset-detail"),
     path("set/<int:set_id>", MemoSetUpdateView.as_view(), name="memoset-update"),
     path("set/<int:set_id>", MemoSetDeleteView.as_view(), name="memoset-delete"),
 ]

--- a/memos/urls.py
+++ b/memos/urls.py
@@ -2,15 +2,15 @@ from django.urls import path
 
 from .views import (
     MemoCreateView,
-    MemoListView,
-    MemoDetailView,
-    MemoUpdateView,
     MemoDeleteView,
+    MemoDetailView,
+    MemoListView,
     MemoSetCreateView,
-    MemoSetListView,
-    MemoSetDetailView,
-    MemoSetUpdateView,
     MemoSetDeleteView,
+    MemoSetDetailView,
+    MemoSetListView,
+    MemoSetUpdateView,
+    MemoUpdateView,
 )
 
 urlpatterns = [

--- a/memos/views.py
+++ b/memos/views.py
@@ -1,16 +1,17 @@
-from rest_framework.views import APIView
-from drf_spectacular.utils import extend_schema, OpenApiParameter
-from rest_framework.response import Response
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from .serializers import (
     MemoCreateSerializer,
     MemoDetailSerializer,
-    MemoUpdateSerializer,
     MemoListSerializer,
     MemoSetCreateSerializer,
     MemoSetDetailSerializer,
-    MemoSetUpdateSerializer,
     MemoSetListSerializer,
+    MemoSetUpdateSerializer,
+    MemoUpdateSerializer,
 )
 
 
@@ -37,7 +38,9 @@ class MemoUpdateView(APIView):
     )
     def put(self, request, memo_id):
         # Placeholder implementation
-        return Response({"message": f"Memo {memo_id} updated"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Memo {memo_id} updated"}, status=status.HTTP_200_OK
+        )
 
 
 class MemoDeleteView(APIView):
@@ -59,13 +62,27 @@ class MemoListView(APIView):
             정렬옵션도 설정할 수 있습니다. View 옵션을 통해 타입, 조회기간, 메모셋을 필터링 할 수 있습니다.",
         parameters=[
             # TODO - MemoListQuerySerializer 구현
-            OpenApiParameter(name="year", description="조회 연도", required=False, type=int),
-            OpenApiParameter(name="month", description="조회 월", required=False, type=int),
-            OpenApiParameter(name="day", description="조회 일", required=False, type=int),
-            OpenApiParameter(name="sort", description="정렬 옵션", required=False, type=str),
-            OpenApiParameter(name="type", description="메모 타입", required=False, type=str),
-            OpenApiParameter(name="memo_set", description="메모셋 필터", required=False, type=str),
-            OpenApiParameter(name="tag", description="태그 필터", required=False, type=str),
+            OpenApiParameter(
+                name="year", description="조회 연도", required=False, type=int
+            ),
+            OpenApiParameter(
+                name="month", description="조회 월", required=False, type=int
+            ),
+            OpenApiParameter(
+                name="day", description="조회 일", required=False, type=int
+            ),
+            OpenApiParameter(
+                name="sort", description="정렬 옵션", required=False, type=str
+            ),
+            OpenApiParameter(
+                name="type", description="메모 타입", required=False, type=str
+            ),
+            OpenApiParameter(
+                name="memo_set", description="메모셋 필터", required=False, type=str
+            ),
+            OpenApiParameter(
+                name="tag", description="태그 필터", required=False, type=str
+            ),
         ],
         responses={200: MemoListSerializer},
         tags=["Memos"],
@@ -84,7 +101,9 @@ class MemoDetailView(APIView):
     )
     def get(self, request, memo_id):
         # Placeholder implementation
-        return Response({"message": f"Details of memo {memo_id}"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Details of memo {memo_id}"}, status=status.HTTP_200_OK
+        )
 
 
 class MemoSetCreateView(APIView):
@@ -122,7 +141,9 @@ class MemoSetUpdateView(APIView):
     )
     def put(self, request, set_id):
         # Placeholder implementation
-        return Response({"message": f"Memo set {set_id} updated"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Memo set {set_id} updated"}, status=status.HTTP_200_OK
+        )
 
 
 class MemoSetListView(APIView):
@@ -146,4 +167,6 @@ class MemoSetDetailView(APIView):
     )
     def get(self, request, set_id):
         # Placeholder implementation
-        return Response({"message": f"Details of memo set {set_id}"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Details of memo set {set_id}"}, status=status.HTTP_200_OK
+        )

--- a/memos/views.py
+++ b/memos/views.py
@@ -1,3 +1,149 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, OpenApiParameter
+from rest_framework.response import Response
+from rest_framework import status
+from .serializers import (
+    MemoCreateSerializer,
+    MemoDetailSerializer,
+    MemoUpdateSerializer,
+    MemoListSerializer,
+    MemoSetCreateSerializer,
+    MemoSetDetailSerializer,
+    MemoSetUpdateSerializer,
+    MemoSetListSerializer,
+)
 
-# Create your views here.
+
+class MemoCreateView(APIView):
+    @extend_schema(
+        summary="메모 등록",
+        description="새로운 메모를 등록합니다. 등록시 메모타입 (일반, 캘린더, Todo)를 지정할 수 있습니다. 등록시 MemoSet을 지정할 수 있습니다.",
+        request=MemoCreateSerializer,
+        responses={201: MemoDetailSerializer},
+        tags=["Memos"],
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Memo created"}, status=status.HTTP_201_CREATED)
+
+
+class MemoUpdateView(APIView):
+    @extend_schema(
+        summary="메모 수정",
+        description="기존 메모의 내용을 수정합니다. 메모의 내용과 타입, 메모셋의 위치를 변경할 수 있습니다.",
+        request=MemoUpdateSerializer,
+        responses={200: MemoDetailSerializer},
+        tags=["Memos"],
+    )
+    def put(self, request, memo_id):
+        # Placeholder implementation
+        return Response({"message": f"Memo {memo_id} updated"}, status=status.HTTP_200_OK)
+
+
+class MemoDeleteView(APIView):
+    @extend_schema(
+        summary="메모 삭제",
+        description="특정 메모를 삭제합니다.",
+        responses={204: None},
+        tags=["Memos"],
+    )
+    def delete(self, request, memo_id):
+        # Placeholder implementation
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MemoListView(APIView):
+    @extend_schema(
+        summary="메모 조회",
+        description="날짜와 분류 기준으로 메모를 조회합니다. 연도, 월, 일 단위로 조회할 수 있으며, \
+            정렬옵션도 설정할 수 있습니다. View 옵션을 통해 타입, 조회기간, 메모셋을 필터링 할 수 있습니다.",
+        parameters=[
+            # TODO - MemoListQuerySerializer 구현
+            OpenApiParameter(name="year", description="조회 연도", required=False, type=int),
+            OpenApiParameter(name="month", description="조회 월", required=False, type=int),
+            OpenApiParameter(name="day", description="조회 일", required=False, type=int),
+            OpenApiParameter(name="sort", description="정렬 옵션", required=False, type=str),
+            OpenApiParameter(name="type", description="메모 타입", required=False, type=str),
+            OpenApiParameter(name="memo_set", description="메모셋 필터", required=False, type=str),
+            OpenApiParameter(name="tag", description="태그 필터", required=False, type=str),
+        ],
+        responses={200: MemoListSerializer},
+        tags=["Memos"],
+    )
+    def get(self, request):
+        # Placeholder implementation
+        return Response({"message": "List of memos"}, status=status.HTTP_200_OK)
+
+
+class MemoDetailView(APIView):
+    @extend_schema(
+        summary="메모 디테일 조회",
+        description="특정 메모의 세부 정보를 조회합니다.",
+        responses={200: MemoDetailSerializer},
+        tags=["Memos"],
+    )
+    def get(self, request, memo_id):
+        # Placeholder implementation
+        return Response({"message": f"Details of memo {memo_id}"}, status=status.HTTP_200_OK)
+
+
+class MemoSetCreateView(APIView):
+    @extend_schema(
+        summary="메모셋 추가",
+        description="새로운 메모셋을 생성합니다.",
+        request=MemoSetCreateSerializer,
+        responses={201: MemoSetDetailSerializer},
+        tags=["MemoSets"],
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Memo set created"}, status=status.HTTP_201_CREATED)
+
+
+class MemoSetDeleteView(APIView):
+    @extend_schema(
+        summary="메모셋 삭제",
+        description="메모셋을 삭제합니다. Set 삭제시 하위 원소처리 관련 정책 적용",
+        responses={204: None},
+        tags=["MemoSets"],
+    )
+    def delete(self, request, set_id):
+        # Placeholder implementation
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MemoSetUpdateView(APIView):
+    @extend_schema(
+        summary="메모셋 수정",
+        description="메모셋을 수정합니다.",
+        request=MemoSetUpdateSerializer,
+        responses={200: MemoSetDetailSerializer},
+        tags=["MemoSets"],
+    )
+    def put(self, request, set_id):
+        # Placeholder implementation
+        return Response({"message": f"Memo set {set_id} updated"}, status=status.HTTP_200_OK)
+
+
+class MemoSetListView(APIView):
+    @extend_schema(
+        summary="메모셋 조회",
+        description="메모셋을 조회합니다.",
+        responses={200: MemoSetListSerializer},
+        tags=["MemoSets"],
+    )
+    def get(self, request):
+        # Placeholder implementation
+        return Response({"message": "List of memo sets"}, status=status.HTTP_200_OK)
+
+
+class MemoSetDetailView(APIView):
+    @extend_schema(
+        summary="메모셋 디테일 조회",
+        description="메모셋의 세부 정보를 조회합니다.",
+        responses={200: MemoSetDetailSerializer},
+        tags=["MemoSets"],
+    )
+    def get(self, request, set_id):
+        # Placeholder implementation
+        return Response({"message": f"Details of memo set {set_id}"}, status=status.HTTP_200_OK)

--- a/tags/serializers.py
+++ b/tags/serializers.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers as s
+
+
+class TagCreateSerializer(s.Serializer):
+    pass
+
+
+class TagDetailSerializer(s.Serializer):
+    pass
+
+
+class TagLabelSerializer(s.Serializer):
+    pass
+
+
+class TagUpdateSerializer(s.Serializer):
+    pass
+
+
+class TagListSerializer(s.Serializer):
+    pass

--- a/tags/urls.py
+++ b/tags/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
+
 from .views import (
     TagCreateView,
-    TagLabelView,
     TagDeleteView,
-    TagUpdateView,
-    TagListView,
     TagDetailView,
+    TagLabelView,
+    TagListView,
+    TagUpdateView,
 )
 
 urlpatterns = [

--- a/tags/urls.py
+++ b/tags/urls.py
@@ -1,0 +1,18 @@
+from django.urls import path
+from .views import (
+    TagCreateView,
+    TagLabelView,
+    TagDeleteView,
+    TagUpdateView,
+    TagListView,
+    TagDetailView,
+)
+
+urlpatterns = [
+    path("", TagCreateView.as_view(), name="tag-create"),
+    path("<int:tag_id>/label", TagLabelView.as_view(), name="tag-label"),
+    path("<int:tag_id>", TagDeleteView.as_view(), name="tag-delete"),
+    path("<int:tag_id>", TagUpdateView.as_view(), name="tag-update"),
+    path("", TagListView.as_view(), name="tag-list"),
+    path("<int:tag_id>", TagDetailView.as_view(), name="tag-detail"),
+]

--- a/tags/views.py
+++ b/tags/views.py
@@ -1,3 +1,81 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.generics import ListAPIView
+from drf_spectacular.utils import extend_schema
+from rest_framework.response import Response
+from rest_framework import status
+from .serializers import (
+    TagCreateSerializer,
+    TagDetailSerializer,
+    TagLabelSerializer,
+    TagUpdateSerializer,
+    TagListSerializer
+)
 
-# Create your views here.
+class TagCreateView(APIView):
+    @extend_schema(
+        summary="태그 추가",
+        description="새로운 태그를 생성하여 메모, 투두, 캘린더 항목에 사용할 수 있도록 합니다.",
+        request=TagCreateSerializer,
+        responses={201: TagDetailSerializer},
+        tags=['Tags']
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Tag created"}, status=status.HTTP_201_CREATED)
+
+class TagLabelView(APIView):
+    @extend_schema(
+        summary="태그 라벨링",
+        description="태그를 라벨링합니다. 라벨링이란, 메모, 투두, 캘린더 아이디를 참조하는 것을 의미합니다.",
+        request=TagLabelSerializer,
+        responses={200: TagDetailSerializer},
+        tags=['Tags']
+    )
+    def post(self, request, tag_id):
+        # Placeholder implementation
+        return Response({"message": f"Tag {tag_id} labeled"}, status=status.HTTP_200_OK)
+
+class TagDeleteView(APIView):
+    @extend_schema(
+        summary="태그 삭제",
+        description="특정 태그를 삭제합니다.",
+        responses={204: None},
+        tags=['Tags']
+    )
+    def delete(self, request, tag_id):
+        # Placeholder implementation
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class TagUpdateView(APIView):
+    @extend_schema(
+        summary="태그 이름 변경",
+        description="태그 이름을 변경합니다.",
+        request=TagUpdateSerializer,
+        responses={200: TagDetailSerializer},
+        tags=['Tags']
+    )
+    def put(self, request, tag_id):
+        # Placeholder implementation
+        return Response({"message": f"Tag {tag_id} updated"}, status=status.HTTP_200_OK)
+
+class TagListView(ListAPIView):
+    @extend_schema(
+        summary="태그 조회",
+        description="유저가 생성한 모든 태그를 조회합니다.",
+        responses={200: TagListSerializer},
+        tags=['Tags']
+    )
+    def get(self, request):
+        # Placeholder implementation
+        return Response({"message": "List of tags"}, status=status.HTTP_200_OK)
+
+class TagDetailView(APIView):
+    @extend_schema(
+        summary="태그 디테일 조회",
+        description="유저가 생성한 태그의 detail을 조회합니다.",
+        responses={200: TagDetailSerializer},
+        tags=['Tags']
+    )
+    def get(self, request, tag_id):
+        # Placeholder implementation
+        return Response({"message": f"Details of tag {tag_id}"}, status=status.HTTP_200_OK)

--- a/tags/views.py
+++ b/tags/views.py
@@ -1,15 +1,17 @@
-from rest_framework.views import APIView
-from rest_framework.generics import ListAPIView
 from drf_spectacular.utils import extend_schema
-from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from .serializers import (
     TagCreateSerializer,
     TagDetailSerializer,
     TagLabelSerializer,
+    TagListSerializer,
     TagUpdateSerializer,
-    TagListSerializer
 )
+
 
 class TagCreateView(APIView):
     @extend_schema(
@@ -17,11 +19,12 @@ class TagCreateView(APIView):
         description="새로운 태그를 생성하여 메모, 투두, 캘린더 항목에 사용할 수 있도록 합니다.",
         request=TagCreateSerializer,
         responses={201: TagDetailSerializer},
-        tags=['Tags']
+        tags=["Tags"],
     )
     def post(self, request):
         # Placeholder implementation
         return Response({"message": "Tag created"}, status=status.HTTP_201_CREATED)
+
 
 class TagLabelView(APIView):
     @extend_schema(
@@ -29,22 +32,24 @@ class TagLabelView(APIView):
         description="태그를 라벨링합니다. 라벨링이란, 메모, 투두, 캘린더 아이디를 참조하는 것을 의미합니다.",
         request=TagLabelSerializer,
         responses={200: TagDetailSerializer},
-        tags=['Tags']
+        tags=["Tags"],
     )
     def post(self, request, tag_id):
         # Placeholder implementation
         return Response({"message": f"Tag {tag_id} labeled"}, status=status.HTTP_200_OK)
+
 
 class TagDeleteView(APIView):
     @extend_schema(
         summary="태그 삭제",
         description="특정 태그를 삭제합니다.",
         responses={204: None},
-        tags=['Tags']
+        tags=["Tags"],
     )
     def delete(self, request, tag_id):
         # Placeholder implementation
         return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class TagUpdateView(APIView):
     @extend_schema(
@@ -52,30 +57,34 @@ class TagUpdateView(APIView):
         description="태그 이름을 변경합니다.",
         request=TagUpdateSerializer,
         responses={200: TagDetailSerializer},
-        tags=['Tags']
+        tags=["Tags"],
     )
     def put(self, request, tag_id):
         # Placeholder implementation
         return Response({"message": f"Tag {tag_id} updated"}, status=status.HTTP_200_OK)
+
 
 class TagListView(ListAPIView):
     @extend_schema(
         summary="태그 조회",
         description="유저가 생성한 모든 태그를 조회합니다.",
         responses={200: TagListSerializer},
-        tags=['Tags']
+        tags=["Tags"],
     )
     def get(self, request):
         # Placeholder implementation
         return Response({"message": "List of tags"}, status=status.HTTP_200_OK)
+
 
 class TagDetailView(APIView):
     @extend_schema(
         summary="태그 디테일 조회",
         description="유저가 생성한 태그의 detail을 조회합니다.",
         responses={200: TagDetailSerializer},
-        tags=['Tags']
+        tags=["Tags"],
     )
     def get(self, request, tag_id):
         # Placeholder implementation
-        return Response({"message": f"Details of tag {tag_id}"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Details of tag {tag_id}"}, status=status.HTTP_200_OK
+        )

--- a/todos/urls.py
+++ b/todos/urls.py
@@ -1,18 +1,19 @@
 from django.urls import path
+
 from .views import (
+    SubTodoCreateView,
+    SubTodoStatusUpdateView,
     TodoCreateView,
     TodoDeleteView,
+    TodoDetailView,
+    TodoListView,
+    TodoSetCreateView,
     TodoSetDeleteView,
     TodoSetDetailView,
     TodoSetListView,
     TodoSetUpdateView,
-    TodoUpdateView,
-    TodoListView,
-    TodoDetailView,
     TodoStatusUpdateView,
-    SubTodoCreateView,
-    SubTodoStatusUpdateView,
-    TodoSetCreateView,
+    TodoUpdateView,
 )
 
 urlpatterns = [

--- a/todos/views.py
+++ b/todos/views.py
@@ -1,8 +1,8 @@
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
+from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.generics import ListAPIView
 
 from .serializers import (
     SubTodoCreateSerializer,
@@ -54,7 +54,9 @@ class TodoUpdateView(APIView):
     )
     def put(self, request, todo_id):
         # Placeholder implementation
-        return Response({"message": f"Todo {todo_id} updated"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Todo {todo_id} updated"}, status=status.HTTP_200_OK
+        )
 
 
 class TodoListView(ListAPIView):
@@ -63,12 +65,17 @@ class TodoListView(ListAPIView):
         description="사용자의 Todo 항목을 조회합니다. 이때 todo_set_id와 complete_date, tag를 통해 필터링 할 수 있습니다.",
         parameters=[
             OpenApiParameter(
-                name="todo_set_id", description="필터링할 Todo Set ID", required=False, type=int
+                name="todo_set_id",
+                description="필터링할 Todo Set ID",
+                required=False,
+                type=int,
             ),
             OpenApiParameter(
                 name="complete_date", description="완료 날짜", required=False, type=str
             ),
-            OpenApiParameter(name="tag", description="태그 필터", required=False, type=str),
+            OpenApiParameter(
+                name="tag", description="태그 필터", required=False, type=str
+            ),
         ],
         responses={200: TodoListSerializer},
         tags=["Todos"],
@@ -87,7 +94,9 @@ class TodoDetailView(APIView):
     )
     def get(self, request, todo_id):
         # Placeholder implementation
-        return Response({"message": f"Detail for Todo {todo_id}"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Detail for Todo {todo_id}"}, status=status.HTTP_200_OK
+        )
 
 
 class TodoStatusUpdateView(APIView):
@@ -116,7 +125,8 @@ class SubTodoCreateView(APIView):
     def post(self, request, todo_id):
         # Placeholder implementation
         return Response(
-            {"message": f"Sub-task created for Todo {todo_id}"}, status=status.HTTP_201_CREATED
+            {"message": f"Sub-task created for Todo {todo_id}"},
+            status=status.HTTP_201_CREATED,
         )
 
 
@@ -171,7 +181,9 @@ class TodoSetUpdateView(APIView):
     )
     def put(self, request, set_id):
         # Placeholder implementation
-        return Response({"message": f"Todo set {set_id} updated"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Todo set {set_id} updated"}, status=status.HTTP_200_OK
+        )
 
 
 class TodoSetListView(ListAPIView):
@@ -195,4 +207,6 @@ class TodoSetDetailView(APIView):
     )
     def get(self, request, set_id):
         # Placeholder implementation
-        return Response({"message": f"Details of todo set {set_id}"}, status=status.HTTP_200_OK)
+        return Response(
+            {"message": f"Details of todo set {set_id}"}, status=status.HTTP_200_OK
+        )

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from users.views import Login, SignUp, Logout
+from users.views import Login, Logout, SignUp
 
 urlpatterns = [
     path("signup/", SignUp.as_view()),


### PR DESCRIPTION
## 📌 PR 요약
<!-- PR의 목적을 한 줄로 요약해 주세요 -->
본 PR은 PLANA-58의 작업 중 Memos, MemoSet, Tags 도메인의 urls.py와 views.py, serializers.py를 생성하였습니다.

## 📝 변경 사항
<!-- 변경된 내용을 간략히 설명해 주세요. -->
- memos
  - urls
  - views
  - serializers
- tags
  - urls
  - views
  - serializers

## 🤔 이유
<!-- 해당 변경이 필요한 이유를 설명해 주세요. -->
노션에서 초벌로 작성한 API 문서를 drf_spectacular로 옮기는 중~


## ✅ 체크리스트
- [ ] 코드가 빌드 및 테스트가 통과합니다.
- [ ] Lint 체크가 완료되었습니다.
- [ ] 관련 문서(README 등)가 업데이트되었습니다.
- [x] 관련 이슈에 연결되었습니다. (연결된 이슈: PLANA-58)

## 📷 스크린샷
<!-- UI 변화가 있거나 테스트 결과 등을 이미지로 첨부해 주세요 -->
<img width="1470" alt="Screenshot 2024-11-09 at 11 46 44" src="https://github.com/user-attachments/assets/5c2f4b8d-aafe-4064-acba-d5f077412a1b">

## 🔗 관련 링크
<!-- 관련된 외부 문서나 참고 링크가 있다면 추가해 주세요 -->

## 🚩 기타 참고 사항
<!-- 코드 리뷰어가 알아야 할 추가 사항이나 참고할 만한 내용을 적어주세요 -->
**버그**

views.py에서 같은 이름의 path가 등록된 경우 첫번째 View에만 요청이 전달되는 문제가 발생하였습니다. 추후 실제 API 구현단계에서 리팩토링 과정에서 해결될 예정입니다. PLANA-81에서 이를 참조하였습니다.

**남은 할 일**

Request, Response Body, Header, Parameters 정의해야 합니다. Serializer를 작성해야 합니다.