### PR TITLE
PLANA-88 fix: Add '*' for ALLOWED_HOST in settings.py

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = "django-insecure-e(vw6xfk1ga9q-87j@%4#o6xu$yk1sqqi(6_h$o#6vj#@6#h70
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition


### PR DESCRIPTION
- ALLOWED_HOSTS에 `['*']`을 추가하기 ∵ DEBUG = True인 경우에는 ALLOWED_HOST에 다음 내용을 자동으로 추가하기 때문에 [`[chltm.mooo.com](http://chltm.mooo.com/)`](http://chltm.mooo.com) 같은 호스트로는 접근이 불가해집니다.
    
```jsx
['.localhost', '127.0.0.1', '[::1]']
```
    
<img width="1125" alt="Screenshot 2024-11-15 at 19 57 31" src="https://github.com/user-attachments/assets/842313eb-3174-49aa-9db2-b0f745e4b4a2">
