### PR TITLE
PLANA-83-Memo-Serializer-Object

### DIFF
--- a/memos/serializers.py
+++ b/memos/serializers.py
@@ -1,41 +1,22 @@
+from django.contrib.auth import get_user_model
 from rest_framework import serializers as s
 
+from memos.models import Memo, MemoSet
 
-class MemoCreateSerializer(s.Serializer):
-    pass
-
-
-class MemoListSerializer(s.Serializer):
-    pass
+User = get_user_model()
 
 
-class MemoDetailSerializer(s.Serializer):
-    pass
+class MemoDetailSerializer(s.ModelSerializer):
+    memo_set = s.StringRelatedField()
+
+    class Meta:
+        model = Memo
+        fields = "__all__"
 
 
-class MemoUpdateSerializer(s.Serializer):
-    pass
+class MemoSetDetailSerializer(s.ModelSerializer):
+    user = s.StringRelatedField()
 
-
-class MemoDeleteSerializer(s.Serializer):
-    pass
-
-
-class MemoSetCreateSerializer(s.Serializer):
-    pass
-
-
-class MemoSetListSerializer(s.Serializer):
-    pass
-
-
-class MemoSetDetailSerializer(s.Serializer):
-    pass
-
-
-class MemoSetUpdateSerializer(s.Serializer):
-    pass
-
-
-class MemoSetDeleteSerializer(s.Serializer):
-    pass
+    class Meta:
+        model = MemoSet
+        fields = "__all__"

--- a/memos/urls.py
+++ b/memos/urls.py
@@ -1,29 +1,20 @@
 from django.urls import path
 
 from .views import (
-    MemoCreateView,
-    MemoDeleteView,
     MemoDetailView,
     MemoListView,
-    MemoSetCreateView,
-    MemoSetDeleteView,
     MemoSetDetailView,
     MemoSetListView,
-    MemoSetUpdateView,
-    MemoUpdateView,
 )
 
-urlpatterns = [
-    ### Memo
-    path("", MemoCreateView.as_view(), name="memo-create"),
+memo_urls = [
     path("", MemoListView.as_view(), name="memo-list"),
     path("<int:memo_id>", MemoDetailView.as_view(), name="memo-detail"),
-    path("<int:memo_id>", MemoUpdateView.as_view(), name="memo-update"),
-    path("<int:memo_id>", MemoDeleteView.as_view(), name="memo-delete"),
-    ### Memoset
-    path("set", MemoSetCreateView.as_view(), name="memoset-create"),
+]
+
+memoset_urls = [
     path("set", MemoSetListView.as_view(), name="memoset-list"),
     path("set/<int:set_id>", MemoSetDetailView.as_view(), name="memoset-detail"),
-    path("set/<int:set_id>", MemoSetUpdateView.as_view(), name="memoset-update"),
-    path("set/<int:set_id>", MemoSetDeleteView.as_view(), name="memoset-delete"),
 ]
+
+urlpatterns = memo_urls + memoset_urls

--- a/memos/views.py
+++ b/memos/views.py
@@ -4,14 +4,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .serializers import (
-    MemoCreateSerializer,
     MemoDetailSerializer,
-    MemoListSerializer,
-    MemoSetCreateSerializer,
     MemoSetDetailSerializer,
-    MemoSetListSerializer,
-    MemoSetUpdateSerializer,
-    MemoUpdateSerializer,
 )
 
 
@@ -21,7 +15,6 @@ class MemoListView(APIView):
         description="날짜와 분류 기준으로 메모를 조회합니다. 연도, 월, 일 단위로 조회할 수 있으며, \
             정렬옵션도 설정할 수 있습니다. View 옵션을 통해 타입, 조회기간, 메모셋을 필터링 할 수 있습니다.",
         parameters=[
-            # TODO - MemoListQuerySerializer 구현
             OpenApiParameter(
                 name="year", description="조회 연도", required=False, type=int
             ),
@@ -38,13 +31,13 @@ class MemoListView(APIView):
                 name="type", description="메모 타입", required=False, type=str
             ),
             OpenApiParameter(
-                name="memo_set", description="메모셋 필터", required=False, type=str
+                name="memo_set", description="메모셋 필터, CSV", required=False, type=str
             ),
             OpenApiParameter(
-                name="tag", description="태그 필터", required=False, type=str
+                name="tag", description="태그 필터, CSV", required=False, type=str
             ),
         ],
-        responses={200: MemoListSerializer},
+        responses={200: MemoDetailSerializer(many=True)},
         tags=["Memos"],
     )
     def get(self, request):
@@ -54,7 +47,7 @@ class MemoListView(APIView):
     @extend_schema(
         summary="메모 등록",
         description="새로운 메모를 등록합니다. 등록시 메모타입 (일반, 캘린더, Todo)를 지정할 수 있습니다. 등록시 MemoSet을 지정할 수 있습니다.",
-        request=MemoCreateSerializer,
+        request=MemoDetailSerializer,
         responses={201: MemoDetailSerializer},
         tags=["Memos"],
     )
@@ -79,7 +72,7 @@ class MemoDetailView(APIView):
     @extend_schema(
         summary="메모 수정",
         description="기존 메모의 내용을 수정합니다. 메모의 내용과 타입, 메모셋의 위치를 변경할 수 있습니다.",
-        request=MemoUpdateSerializer,
+        request=MemoDetailSerializer,
         responses={200: MemoDetailSerializer},
         tags=["Memos"],
     )
@@ -92,7 +85,7 @@ class MemoDetailView(APIView):
     @extend_schema(
         summary="메모 삭제",
         description="특정 메모를 삭제합니다.",
-        responses={204: None},
+        responses={204: MemoDetailSerializer},
         tags=["Memos"],
     )
     def delete(self, request, memo_id):
@@ -104,7 +97,7 @@ class MemoSetListView(APIView):
     @extend_schema(
         summary="메모셋 조회",
         description="메모셋을 조회합니다.",
-        responses={200: MemoSetListSerializer},
+        responses={200: MemoSetDetailSerializer(many=True)},
         tags=["MemoSets"],
     )
     def get(self, request):
@@ -114,7 +107,7 @@ class MemoSetListView(APIView):
     @extend_schema(
         summary="메모셋 추가",
         description="새로운 메모셋을 생성합니다.",
-        request=MemoSetCreateSerializer,
+        request=MemoSetDetailSerializer,
         responses={201: MemoSetDetailSerializer},
         tags=["MemoSets"],
     )
@@ -139,7 +132,7 @@ class MemoSetDetailView(APIView):
     @extend_schema(
         summary="메모셋 삭제",
         description="메모셋을 삭제합니다. Set 삭제시 하위 원소처리 관련 정책 적용",
-        responses={204: None},
+        responses={204: MemoSetDetailSerializer},
         tags=["MemoSets"],
     )
     def delete(self, request, set_id):
@@ -149,7 +142,7 @@ class MemoSetDetailView(APIView):
     @extend_schema(
         summary="메모셋 수정",
         description="메모셋을 수정합니다.",
-        request=MemoSetUpdateSerializer,
+        request=MemoSetDetailSerializer,
         responses={200: MemoSetDetailSerializer},
         tags=["MemoSets"],
     )

--- a/memos/views.py
+++ b/memos/views.py
@@ -15,46 +15,6 @@ from .serializers import (
 )
 
 
-class MemoCreateView(APIView):
-    @extend_schema(
-        summary="메모 등록",
-        description="새로운 메모를 등록합니다. 등록시 메모타입 (일반, 캘린더, Todo)를 지정할 수 있습니다. 등록시 MemoSet을 지정할 수 있습니다.",
-        request=MemoCreateSerializer,
-        responses={201: MemoDetailSerializer},
-        tags=["Memos"],
-    )
-    def post(self, request):
-        # Placeholder implementation
-        return Response({"message": "Memo created"}, status=status.HTTP_201_CREATED)
-
-
-class MemoUpdateView(APIView):
-    @extend_schema(
-        summary="메모 수정",
-        description="기존 메모의 내용을 수정합니다. 메모의 내용과 타입, 메모셋의 위치를 변경할 수 있습니다.",
-        request=MemoUpdateSerializer,
-        responses={200: MemoDetailSerializer},
-        tags=["Memos"],
-    )
-    def put(self, request, memo_id):
-        # Placeholder implementation
-        return Response(
-            {"message": f"Memo {memo_id} updated"}, status=status.HTTP_200_OK
-        )
-
-
-class MemoDeleteView(APIView):
-    @extend_schema(
-        summary="메모 삭제",
-        description="특정 메모를 삭제합니다.",
-        responses={204: None},
-        tags=["Memos"],
-    )
-    def delete(self, request, memo_id):
-        # Placeholder implementation
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-
 class MemoListView(APIView):
     @extend_schema(
         summary="메모 조회",
@@ -91,6 +51,17 @@ class MemoListView(APIView):
         # Placeholder implementation
         return Response({"message": "List of memos"}, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        summary="메모 등록",
+        description="새로운 메모를 등록합니다. 등록시 메모타입 (일반, 캘린더, Todo)를 지정할 수 있습니다. 등록시 MemoSet을 지정할 수 있습니다.",
+        request=MemoCreateSerializer,
+        responses={201: MemoDetailSerializer},
+        tags=["Memos"],
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Memo created"}, status=status.HTTP_201_CREATED)
+
 
 class MemoDetailView(APIView):
     @extend_schema(
@@ -105,45 +76,28 @@ class MemoDetailView(APIView):
             {"message": f"Details of memo {memo_id}"}, status=status.HTTP_200_OK
         )
 
-
-class MemoSetCreateView(APIView):
     @extend_schema(
-        summary="메모셋 추가",
-        description="새로운 메모셋을 생성합니다.",
-        request=MemoSetCreateSerializer,
-        responses={201: MemoSetDetailSerializer},
-        tags=["MemoSets"],
+        summary="메모 수정",
+        description="기존 메모의 내용을 수정합니다. 메모의 내용과 타입, 메모셋의 위치를 변경할 수 있습니다.",
+        request=MemoUpdateSerializer,
+        responses={200: MemoDetailSerializer},
+        tags=["Memos"],
     )
-    def post(self, request):
-        # Placeholder implementation
-        return Response({"message": "Memo set created"}, status=status.HTTP_201_CREATED)
-
-
-class MemoSetDeleteView(APIView):
-    @extend_schema(
-        summary="메모셋 삭제",
-        description="메모셋을 삭제합니다. Set 삭제시 하위 원소처리 관련 정책 적용",
-        responses={204: None},
-        tags=["MemoSets"],
-    )
-    def delete(self, request, set_id):
-        # Placeholder implementation
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-
-class MemoSetUpdateView(APIView):
-    @extend_schema(
-        summary="메모셋 수정",
-        description="메모셋을 수정합니다.",
-        request=MemoSetUpdateSerializer,
-        responses={200: MemoSetDetailSerializer},
-        tags=["MemoSets"],
-    )
-    def put(self, request, set_id):
+    def put(self, request, memo_id):
         # Placeholder implementation
         return Response(
-            {"message": f"Memo set {set_id} updated"}, status=status.HTTP_200_OK
+            {"message": f"Memo {memo_id} updated"}, status=status.HTTP_200_OK
         )
+
+    @extend_schema(
+        summary="메모 삭제",
+        description="특정 메모를 삭제합니다.",
+        responses={204: None},
+        tags=["Memos"],
+    )
+    def delete(self, request, memo_id):
+        # Placeholder implementation
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class MemoSetListView(APIView):
@@ -157,6 +111,17 @@ class MemoSetListView(APIView):
         # Placeholder implementation
         return Response({"message": "List of memo sets"}, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        summary="메모셋 추가",
+        description="새로운 메모셋을 생성합니다.",
+        request=MemoSetCreateSerializer,
+        responses={201: MemoSetDetailSerializer},
+        tags=["MemoSets"],
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Memo set created"}, status=status.HTTP_201_CREATED)
+
 
 class MemoSetDetailView(APIView):
     @extend_schema(
@@ -169,4 +134,27 @@ class MemoSetDetailView(APIView):
         # Placeholder implementation
         return Response(
             {"message": f"Details of memo set {set_id}"}, status=status.HTTP_200_OK
+        )
+
+    @extend_schema(
+        summary="메모셋 삭제",
+        description="메모셋을 삭제합니다. Set 삭제시 하위 원소처리 관련 정책 적용",
+        responses={204: None},
+        tags=["MemoSets"],
+    )
+    def delete(self, request, set_id):
+        # Placeholder implementation
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        summary="메모셋 수정",
+        description="메모셋을 수정합니다.",
+        request=MemoSetUpdateSerializer,
+        responses={200: MemoSetDetailSerializer},
+        tags=["MemoSets"],
+    )
+    def put(self, request, set_id):
+        # Placeholder implementation
+        return Response(
+            {"message": f"Memo set {set_id} updated"}, status=status.HTTP_200_OK
         )


### PR DESCRIPTION
# 메모 및 메모셋 시리얼라이저와 뷰 개선

## PR 개요 ✨
이 PR은 `Memo`와 `MemoSet` 모델의 시리얼라이저와 뷰를 개선하여 코드의 일관성을 높이고 불필요한 뷰와 시리얼라이저를 정리했습니다. 메모 및 메모셋 생성, 조회, 수정, 삭제 기능을 지원하는 시리얼라이저와 뷰가 통합되었으며, 필요한 문서화가 추가되었습니다.

- `MemoDetailSerializer` 및 `MemoSetDetailSerializer`에 모든 필드를 반환하는 `"__all__"` 설정이 추가되었습니다.
- `MemoListView` 및 `MemoSetListView`에서 조회 및 생성 작업을 하나의 뷰에서 관리하도록 통합되었습니다.

## 주요 변경사항 📝
1. **시리얼라이저 통합**:
   - 불필요한 `MemoCreateSerializer`, `MemoUpdateSerializer`, `MemoSetCreateSerializer` 등을 삭제하고 `MemoDetailSerializer`와 `MemoSetDetailSerializer`로 통합하여 모델 필드 전체를 활용할 수 있도록 개선했습니다.

2. **뷰 로직 수정**:
   - `MemoListView`와 `MemoSetListView`에서 `GET` 메서드로 조회, `POST` 메서드로 생성 작업을 처리하도록 통합했습니다.
   - `MemoSetDetailView`와 `MemoDetailView`에서 세부사항 조회와 함께 `PUT`, `DELETE` 메서드를 지원하여 수정 및 삭제 작업을 하나의 뷰에서 처리할 수 있게 했습니다.

3. **URL 패턴 리팩토링**:
   - `memo_urls`와 `memoset_urls`로 URL 패턴을 분리하여 `urlpatterns`에 통합하여 관리하기 쉽게 변경했습니다.

## 기대 효과 🌟
이 PR을 통해 메모 및 메모셋 관련 API의 가독성과 유지보수성이 향상되었으며, 중복된 코드가 줄어들어 코드베이스의 단순화 및 구조화를 달성했습니다. 추가적인 시리얼라이저 및 뷰 통합으로 전체 API의 응집력도 높아졌습니다.
