### PR TITLE
PLANA-85-Tag-Serializer

### DIFF
--- a/tags/serializers.py
+++ b/tags/serializers.py
@@ -1,21 +1,37 @@
 from rest_framework import serializers as s
 
-
-class TagCreateSerializer(s.Serializer):
-    pass
-
-
-class TagDetailSerializer(s.Serializer):
-    pass
+from calendars.models import Schedule
+from memos.models import Memo
+from tags.models import Tag
+from todos.models import Todo
 
 
-class TagLabelSerializer(s.Serializer):
-    pass
+class TagDetailSerializer(s.ModelSerializer):
+    user = s.StringRelatedField()
+    schedule = s.PrimaryKeyRelatedField(many=True, read_only=True)
+    memo = s.PrimaryKeyRelatedField(many=True, read_only=True)
+    todo = s.PrimaryKeyRelatedField(many=True, read_only=True)
+
+    class Meta:
+        model = Tag
+        fields = "__all__"
 
 
-class TagUpdateSerializer(s.Serializer):
-    pass
+class TagLabelSerializer(s.ModelSerializer):
+    todo = s.PrimaryKeyRelatedField(queryset=Todo.objects.all(), many=True)
+    memo = s.PrimaryKeyRelatedField(queryset=Memo.objects.all(), many=True)
+    schedule = s.PrimaryKeyRelatedField(queryset=Schedule.objects.all(), many=True)
+
+    class Meta:
+        model = Tag
+        fields = (
+            "todo",
+            "memo",
+            "schedule",
+        )
 
 
-class TagListSerializer(s.Serializer):
-    pass
+class TagTitleSerializer(s.ModelSerializer):
+    class Meta:
+        model = Tag
+        fields = ("title",)

--- a/tags/urls.py
+++ b/tags/urls.py
@@ -1,19 +1,9 @@
 from django.urls import path
 
-from .views import (
-    TagCreateView,
-    TagDeleteView,
-    TagDetailView,
-    TagLabelView,
-    TagListView,
-    TagUpdateView,
-)
+from .views import TagDetailView, TagLabelView, TagListView
 
 urlpatterns = [
-    path("", TagCreateView.as_view(), name="tag-create"),
     path("<int:tag_id>/label", TagLabelView.as_view(), name="tag-label"),
-    path("<int:tag_id>", TagDeleteView.as_view(), name="tag-delete"),
-    path("<int:tag_id>", TagUpdateView.as_view(), name="tag-update"),
     path("", TagListView.as_view(), name="tag-list"),
     path("<int:tag_id>", TagDetailView.as_view(), name="tag-detail"),
 ]

--- a/tags/views.py
+++ b/tags/views.py
@@ -4,26 +4,7 @@ from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import (
-    TagCreateSerializer,
-    TagDetailSerializer,
-    TagLabelSerializer,
-    TagListSerializer,
-    TagUpdateSerializer,
-)
-
-
-class TagCreateView(APIView):
-    @extend_schema(
-        summary="태그 추가",
-        description="새로운 태그를 생성하여 메모, 투두, 캘린더 항목에 사용할 수 있도록 합니다.",
-        request=TagCreateSerializer,
-        responses={201: TagDetailSerializer},
-        tags=["Tags"],
-    )
-    def post(self, request):
-        # Placeholder implementation
-        return Response({"message": "Tag created"}, status=status.HTTP_201_CREATED)
+from .serializers import TagDetailSerializer, TagLabelSerializer, TagTitleSerializer
 
 
 class TagLabelView(APIView):
@@ -39,41 +20,37 @@ class TagLabelView(APIView):
         return Response({"message": f"Tag {tag_id} labeled"}, status=status.HTTP_200_OK)
 
 
-class TagDeleteView(APIView):
+class TagListView(ListAPIView):
+    @extend_schema(
+        summary="태그 조회",
+        description="유저가 생성한 모든 태그를 조회합니다.",
+        responses={200: TagDetailSerializer(many=True)},
+        tags=["Tags"],
+    )
+    def get(self, request):
+        # Placeholder implementation
+        return Response({"message": "List of tags"}, status=status.HTTP_200_OK)
+
     @extend_schema(
         summary="태그 삭제",
         description="특정 태그를 삭제합니다.",
-        responses={204: None},
+        responses={204: TagDetailSerializer},
         tags=["Tags"],
     )
     def delete(self, request, tag_id):
         # Placeholder implementation
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-
-class TagUpdateView(APIView):
     @extend_schema(
         summary="태그 이름 변경",
         description="태그 이름을 변경합니다.",
-        request=TagUpdateSerializer,
+        request=TagTitleSerializer,
         responses={200: TagDetailSerializer},
         tags=["Tags"],
     )
     def put(self, request, tag_id):
         # Placeholder implementation
         return Response({"message": f"Tag {tag_id} updated"}, status=status.HTTP_200_OK)
-
-
-class TagListView(ListAPIView):
-    @extend_schema(
-        summary="태그 조회",
-        description="유저가 생성한 모든 태그를 조회합니다.",
-        responses={200: TagListSerializer},
-        tags=["Tags"],
-    )
-    def get(self, request):
-        # Placeholder implementation
-        return Response({"message": "List of tags"}, status=status.HTTP_200_OK)
 
 
 class TagDetailView(APIView):
@@ -88,3 +65,16 @@ class TagDetailView(APIView):
         return Response(
             {"message": f"Details of tag {tag_id}"}, status=status.HTTP_200_OK
         )
+
+    @extend_schema(
+        summary="태그 추가",
+        description="새로운 태그를 생성하여 메모, 투두, 캘린더 항목에 사용할 수 있도록 합니다.\
+                태그 생성은 단순히 title을 사용하여 생성이 가능하며, 다른 엔티티와 연결하기 \
+                위해서 **태그 라벨링**을 요청해야 합니다.",
+        request=TagTitleSerializer,
+        responses={201: TagDetailSerializer},
+        tags=["Tags"],
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Tag created"}, status=status.HTTP_201_CREATED)

--- a/tags/views.py
+++ b/tags/views.py
@@ -1,4 +1,4 @@
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, OpenApiParameter as P, OpenApiTypes
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
@@ -9,8 +9,8 @@ from .serializers import TagDetailSerializer, TagLabelSerializer, TagTitleSerial
 
 class TagLabelView(APIView):
     @extend_schema(
-        summary="태그 라벨링",
-        description="태그를 라벨링합니다. 라벨링이란, 메모, 투두, 캘린더 아이디를 참조하는 것을 의미합니다.",
+        summary="태그 라벨 추가",
+        description="태그를 라벨링을 합니다. 라벨링이란, 메모, 투두, 캘린더 아이디를 참조하는 것을 의미합니다.",
         request=TagLabelSerializer,
         responses={200: TagDetailSerializer},
         tags=["Tags"],
@@ -18,6 +18,24 @@ class TagLabelView(APIView):
     def post(self, request, tag_id):
         # Placeholder implementation
         return Response({"message": f"Tag {tag_id} labeled"}, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="태그 라벨 제거",
+        description="태그 라벨을 제거합니다. 이때 Query Param으로 제거할 엔티티 ID를 명시해야 합니다.\
+            만일 제시한 ID가 현재 태그 라벨에 연관되지 않는다면 404 Not found를 반환합니다.",
+        parameters=[ 
+            P("schedule", type=OpenApiTypes.INT, location=P.QUERY),
+            P("memo", type=OpenApiTypes.INT, location=P.QUERY),
+            P("todo", type=OpenApiTypes.INT, location=P.QUERY),
+         ],
+         responses={204: TagDetailSerializer},
+         tags=["Tags"],
+    )
+    def delete(self, request, tag_id):
+        # Placeholder implementation
+        return Response(
+            {"message": f"Tag {tag_id} unlabeled"}, status=status.HTTP_204_NO_CONTENT
+        )
 
 
 class TagListView(ListAPIView):
@@ -32,16 +50,6 @@ class TagListView(ListAPIView):
         return Response({"message": "List of tags"}, status=status.HTTP_200_OK)
 
     @extend_schema(
-        summary="태그 삭제",
-        description="특정 태그를 삭제합니다.",
-        responses={204: TagDetailSerializer},
-        tags=["Tags"],
-    )
-    def delete(self, request, tag_id):
-        # Placeholder implementation
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-    @extend_schema(
         summary="태그 이름 변경",
         description="태그 이름을 변경합니다.",
         request=TagTitleSerializer,
@@ -51,6 +59,19 @@ class TagListView(ListAPIView):
     def put(self, request, tag_id):
         # Placeholder implementation
         return Response({"message": f"Tag {tag_id} updated"}, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="태그 추가",
+        description="새로운 태그를 생성하여 메모, 투두, 캘린더 항목에 사용할 수 있도록 합니다.\
+                태그 생성은 단순히 title을 사용하여 생성이 가능하며, 다른 엔티티와 연결하기 \
+                위해서 **태그 라벨링**을 요청해야 합니다.",
+        request=TagTitleSerializer,
+        responses={201: TagDetailSerializer},
+        tags=["Tags"],
+    )
+    def post(self, request):
+        # Placeholder implementation
+        return Response({"message": "Tag created"}, status=status.HTTP_201_CREATED)
 
 
 class TagDetailView(APIView):
@@ -67,14 +88,11 @@ class TagDetailView(APIView):
         )
 
     @extend_schema(
-        summary="태그 추가",
-        description="새로운 태그를 생성하여 메모, 투두, 캘린더 항목에 사용할 수 있도록 합니다.\
-                태그 생성은 단순히 title을 사용하여 생성이 가능하며, 다른 엔티티와 연결하기 \
-                위해서 **태그 라벨링**을 요청해야 합니다.",
-        request=TagTitleSerializer,
-        responses={201: TagDetailSerializer},
+        summary="태그 삭제",
+        description="특정 태그를 삭제합니다.",
+        responses={204: TagDetailSerializer},
         tags=["Tags"],
     )
-    def post(self, request):
+    def delete(self, request, tag_id):
         # Placeholder implementation
-        return Response({"message": "Tag created"}, status=status.HTTP_201_CREATED)
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
# 태그 모듈 리팩토링 PR

## 개요
이 PR은 태그 모듈의 Serializer, View 및 URL 구조를 리팩토링하여 유지보수성을 개선하고, 태그와 관련된 API 동작을 명확히 하기 위해 작성되었습니다. 태그 생성, 라벨링, 수정, 삭제와 같은 주요 기능들을 재구성하고 문서화를 강화했습니다.

## 주요 변경 사항
1. **Serializer 개선**
   - `TagDetailSerializer`, `TagLabelSerializer`, `TagTitleSerializer`로 구체적인 목적에 따라 Serializer를 분리.
   - `PrimaryKeyRelatedField`를 사용하여 태그가 다른 엔티티(`Todo`, `Memo`, `Schedule`)와의 관계를 명확히 표현.

2. **View 리팩토링**
   - 불필요한 View를 제거하고, CRUD 동작을 핵심 View (`TagDetailView`, `TagLabelView`, `TagListView`)에 통합.
   - `@extend_schema`를 활용해 OpenAPI 문서화를 개선하고, 태그 라벨링/삭제 등 주요 기능의 동작을 명확히 설명.

3. **URL 구조 간소화**
   - CRUD 기능을 통합한 View에 맞춰 URL 패턴을 간소화하고, 관련 엔드포인트를 명확히 구성.

## 기대 효과
- **가독성과 유지보수성 향상**: 불필요한 코드와 중복된 Serializer, View를 제거하여 코드베이스를 간소화.
- **API 문서화 강화**: OpenAPI 스키마를 개선하여 API 소비자가 엔드포인트의 동작을 더 쉽게 이해하고 사용할 수 있도록 지원.
- **확장성 증가**: 태그와 관련된 로직이 구조적으로 정리되어, 앞으로의 확장 및 기능 추가가 용이.

이 PR을 통해 태그 모듈이 더 명확하고 효율적인 구조로 개선되었으며, API 사용자의 경험 또한 향상될 것으로 기대됩니다. 🎉