### PR TITLE
PLANA-154 Calendar API

### DIFF
--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -1,3 +1,77 @@
-from django.test import TestCase
+from rest_framework import reverse, status
+from rest_framework.authentication import get_user_model
 
-# Create your tests here.
+from calendars.models import Calendar
+from tests.auth_base_test import TestAuthBase
+
+
+User = get_user_model()
+
+
+class TestCalendarList(TestAuthBase):
+    URL = "/api/v1/calendars/"
+
+    def setUp(self):
+        super().setUp()
+
+        # create a sample Calendar for testing
+        self.calendar = Calendar.objects.create(user=self.user, title="Calendar1")
+
+    def test_get_calendars(self):
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "Calendar1")
+
+    def test_create_calendar(self):
+        payload = {"title": "Calendar2"}
+        response = self.client.post(self.URL, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Calendar.objects.count(), 2)
+        self.assertEqual(Calendar.objects.last().title, "Calendar2")
+
+    def test_create_calendar_invalid(self):
+        payload = {}  # 타이틀 누락
+        response = self.client.post(self.URL, data=payload)
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestCalendarDetail(TestAuthBase):
+    URL = "/api/v1/calendars/"
+
+    def setUp(self):
+        super().setUp()
+
+        # create a sample Calendar for testing
+        self.calendar = Calendar.objects.create(user=self.user, title="Calendar1")
+
+        self.url = f"{self.URL}{self.calendar.title}/"
+
+    def test_get_calendar_detail(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "Calendar1")
+
+    def test_get_calendar_not_found(self):
+        url = f"{self.URL}NonExistentCalendar/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("message", response.data)
+
+    def test_update_calendar(self):
+        payload = {"title": "UpdatedCalendar"}
+        response = self.client.put(self.url, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.calendar.refresh_from_db()
+        self.assertEqual(self.calendar.title, "UpdatedCalendar")
+
+    def test_update_calendar_bad_request(self):
+        payload = {}  # 타이틀 누락
+        response = self.client.put(self.url, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_calendar(self):
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Calendar.objects.filter(id=self.calendar.id).exists())

--- a/calendars/urls.py
+++ b/calendars/urls.py
@@ -11,7 +11,7 @@ from .views import (
 
 calendar_urls = [
     path(
-        "<str:calendar_name>",
+        "<str:calendar_name>/",
         CalendarDetailView.as_view(),
         name="calendar-detail",
     ),
@@ -19,18 +19,18 @@ calendar_urls = [
 ]
 
 schedule_urls = [
-    path("schedule", ScheduleListView.as_view(), name="schedule-list"),
+    path("schedule/", ScheduleListView.as_view(), name="schedule-list"),
     path(
-        "schedule/<int:schedule_id>",
+        "schedule/<int:schedule_id>/",
         ScheduleDetailView.as_view(),
         name="schedule-detail",
     ),
     path(
-        "schedule/<int:schedule_id>/copy",
+        "schedule/<int:schedule_id>/copy/",
         ScheduleCopyView.as_view(),
         name="schedule-copy",
     ),
-    path("schedule/search", ScheduleSearchView.as_view(), name="schedule-search"),
+    path("schedule/search/", ScheduleSearchView.as_view(), name="schedule-search"),
 ]
 
 urlpatterns = calendar_urls + schedule_urls

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -119,8 +119,16 @@ class CalendarDetailView(APIView):
         tags=["Calendars"],
     )
     def delete(self, request, calendar_name):
-        # Placeholder implementation
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        try:
+            instance = self.queryset.get(user=request.user, title=calendar_name)
+
+            serializer = self.serializer_class(instance=instance)
+            instance.delete()
+
+            return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
+
+        except ObjectDoesNotExist:
+            raise NotFound(detail={"message": "캘린더가 존재하지 않습니다."})
 
 
 class ScheduleCopyView(APIView):

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -3,8 +3,11 @@ from datetime import date
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from calendars.models import Calendar
 
 from .serializers import (
     CalendarDetailSerializer,
@@ -17,6 +20,10 @@ class CalendarListView(APIView):
     """
     캘린더들에 대한 작업을 처리합니다. 모든 캘린더를 조회하거나 새 캘린더를 추가합니다.
     """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = CalendarDetailSerializer
+    queryset = Calendar.objects.all()
 
     @extend_schema(
         summary="캘린더 목록 조회",
@@ -35,8 +42,14 @@ class CalendarListView(APIView):
         tags=["Calendars"],
     )
     def post(self, request):
-        # Placeholder implementation
-        return Response({"message": "Calendar created"}, status=status.HTTP_201_CREATED)
+        serializer = self.serializer_class(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"message": "Invalid Request 💀"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        serializer.save(user=request.user)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class CalendarDetailView(APIView):

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -47,7 +47,9 @@ class CalendarListView(APIView):
         tags=["Calendars"],
     )
     def post(self, request):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(
+            data=request.data, context={"request": request}
+        )
         if not serializer.is_valid():
             return Response(
                 {"message": "Invalid Request 💀"}, status=status.HTTP_400_BAD_REQUEST
@@ -81,7 +83,7 @@ class CalendarDetailView(APIView):
             return Response(serializer.data, status=status.HTTP_200_OK)
 
         except ObjectDoesNotExist:
-            raise NotFound(message="해당 캘린더가 존재하지 않습니다.")
+            raise NotFound(detail={"message": "해당 캘린더가 존재하지 않습니다."})
 
     @extend_schema(
         summary="캘린더 속성 수정",

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -32,7 +32,10 @@ class CalendarListView(APIView):
         tags=["Calendars"],
     )
     def get(self, request):
-        return Response({"message": "캘린더 목록 조회완료!"}, status=status.HTTP_200_OK)
+        queryset = self.queryset.filter(user=request.user)
+        serializer = self.serializer_class(instance=queryset, many=True)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         summary="캘린더 생성",


### PR DESCRIPTION
### PR 설명 (Pull Request Description)

#### 개요
이 PR은 **캘린더 관련 API**의 기능 개선 및 오류 처리 로직을 추가하고, 일부 URL 경로의 정규성을 수정하며, 테스트 케이스를 확장합니다.

---

#### 주요 변경 사항

1. **Serializer 변경**
   - `CalendarDetailSerializer`에 다음 변경 사항이 추가되었습니다:
     - `user` 필드를 `PrimaryKeyRelatedField`로 변경하여 `read_only` 설정.
     - `validate` 메서드 추가: `user`와 `title`의 고유성을 검증.
     - `update` 메서드 추가: 속성 업데이트 로직 구현.

2. **View 로직 강화**
   - `CalendarListView`와 `CalendarDetailView`:
     - `permission_classes`로 `IsAuthenticated` 설정.
     - `queryset`과 `serializer_class` 추가.
     - `get`, `post`, `put`, `delete` 메서드에서 객체 조회 및 검증 로직 개선.
     - 에러 처리 로직 추가 (`ObjectDoesNotExist`, `ValidationError`).

3. **URL 정규화**
   - 캘린더 및 스케줄 관련 URL에서 누락된 슬래시(`/`)를 추가하여 RESTful API 표준 준수.

4. **테스트 케이스 추가**
   - 캘린더 API의 CRUD 동작 및 예외 처리에 대한 포괄적인 테스트 작성.
   - 신규 테스트 목록:
     - 캘린더 조회 (`GET`)
     - 캘린더 생성 (`POST`)
     - 잘못된 데이터로 캘린더 생성 시 실패 확인 (`POST`)
     - 캘린더 세부 정보 확인 (`GET`)
     - 캘린더 업데이트 및 실패 테스트 (`PUT`)
     - 캘린더 삭제 (`DELETE`)

---

#### 기대 효과
- API의 **사용성** 및 **안정성** 개선:
  - 요청 데이터의 유효성 검증으로 예외 발생 최소화.
  - 사용자가 의도하지 않은 중복 데이터 생성 방지.
- URL 규칙 정규화로 클라이언트와의 통신 안정성 증가.
- 테스트 추가로 기능 검증 및 유지보수 용이성 향상.

--- 

#### 테스트 방법
1. 로컬 환경에서 서버 실행:
   ```bash
   python manage.py runserver
   ```
2. 다음 명령으로 테스트 실행:
   ```bash
   python manage.py test calendars
   ```
3. Postman 또는 기타 REST 클라이언트로 API 동작 확인:
   - 캘린더 CRUD 테스트
   - 에러 메시지 및 HTTP 상태 코드 확인

---

리뷰 요청드립니다! 😊