### PR TITLE
feat PLANA-167: 기본 memo_set

### DIFF
--- a/memos/views.py
+++ b/memos/views.py
@@ -170,7 +170,9 @@ class MemoListView(APIView):
         tags=["Memos"],
     )
     def post(self, request):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(
+            data=request.data, context={"request": request}
+        )
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### 기본 MemoSet 자동 연결 기능 추가

#### 개요  
이 PR은 새로운 Memo 객체 생성 시 `memo_set` 값이 제공되지 않은 경우 기본 MemoSet으로 자동 연결되도록 기능을 추가합니다. 이를 통해 클라이언트가 `memo_set`을 생략하더라도 올바르게 동작하며, 코드의 유연성과 안정성을 강화합니다.

---

#### 주요 변경사항  
1. **Serializer 수정**  
   - `MemoDetailSerializer`에서 `memo_set` 필드의 `required` 속성을 `False`로 설정.  
   - 새로운 `create` 메서드 추가: `memo_set`이 제공되지 않을 경우 기본 MemoSet(`title="Memo"`)을 자동으로 참조하도록 처리.

2. **테스트 코드 추가 및 수정**  
   - 테스트 데이터 생성 시 기본 MemoSet 제목을 `"Memo"`로 변경.  
   - `test_create_memo_with_default_set` 테스트 추가: `memo_set`을 제공하지 않았을 때 기본 MemoSet으로 연결되는지 검증.

3. **뷰 로직 개선**  
   - `MemoListView`와 `MemoDetailView`에서 `serializer`에 `context` 추가 및 `partial` 속성 명시.

4. **불필요한 테스트 삭제**  
   - `test_update_memo_invalid_data` 테스트 제거: 실질적 검증 가치가 낮은 테스트로 판단되어 삭제.

---

#### 테스트 완료 목록  
- [x] 새로운 Memo 생성 시 `memo_set`이 생략되면 기본 MemoSet으로 연결 확인.  
- [x] 기존 기능이 예상대로 동작하는지 전반적 검증.  
- [x] `memo_set`이 명시적으로 전달될 경우 정확히 연결되는지 확인.  

---

#### 기타 참고사항  
- **TODO:** 기본 MemoSet의 이름을 하드코딩하지 않고 동적으로 처리할 방안 검토 필요.  
- 코드 스타일 및 가독성을 개선하기 위해 추가적으로 리팩토링이 필요할 가능성 있음.  
