### PR TITLE
Implement schedule management features and improvements

### DIFF
--- a/calendars/serializers.py
+++ b/calendars/serializers.py
@@ -1,5 +1,9 @@
+from random import choice
+from types import FunctionType
+from typing import Self
 from django.contrib.auth import get_user_model
 from rest_framework import serializers as s
+from rest_framework.fields import ChoiceField
 
 from calendars.models import Calendar, Schedule
 from memos.models import Memo
@@ -72,3 +76,25 @@ class ScheduleUpdateSerializer(s.ModelSerializer):
             "calendar",
             "participant",
         )
+
+
+class ScheduleViewChoices(s.Serializer):
+    """
+    ScheduleListView GET 요청의 query_params 중에서 `view` Choices를 명시하기 위해 사용되는 serializer 입니다.
+    """
+
+    view = ChoiceField(
+        choices=(
+            "monthly",
+            "daily",
+            "weekly",
+        )
+    )
+
+
+class ScheduleDirectionChoices(s.Serializer):
+    """
+    ScheduleListView GET 요청의 query_params 중에서 `direction` Choices를 명시하기 위해 사용하는 serializer 입니다.
+    """
+
+    direction = ChoiceField(choices=("next", "previous"))

--- a/calendars/serializers.py
+++ b/calendars/serializers.py
@@ -2,6 +2,8 @@ from django.contrib.auth import get_user_model
 from rest_framework import serializers as s
 
 from calendars.models import Calendar, Schedule
+from memos.models import Memo
+from memos.serializers import MemoDetailSerializer
 
 User = get_user_model()
 
@@ -39,11 +41,9 @@ class CalendarDetailSerializer(s.ModelSerializer):
 
 
 class ScheduleDetailSerializer(s.ModelSerializer):
-    participant = s.SlugRelatedField(slug_field="email", read_only=True, many=True)
-    memo = s.HyperlinkedRelatedField(
-        view_name="memo-detail", read_only=True, allow_null=True
-    )
-    calendar = s.HyperlinkedRelatedField(view_name="title", read_only=True, many=False)
+    participant = s.PrimaryKeyRelatedField(read_only=True, many=True)
+    memo = MemoDetailSerializer(required=False)
+    calendar = s.PrimaryKeyRelatedField(read_only=True, many=False)
 
     class Meta:
         model = Schedule

--- a/calendars/serializers.py
+++ b/calendars/serializers.py
@@ -47,7 +47,7 @@ class CalendarDetailSerializer(s.ModelSerializer):
 class ScheduleDetailSerializer(s.ModelSerializer):
     participant = s.PrimaryKeyRelatedField(read_only=True, many=True)
     memo = MemoDetailSerializer(required=False)
-    calendar = s.PrimaryKeyRelatedField(read_only=True, many=False)
+    calendar = s.PrimaryKeyRelatedField(queryset=Calendar.objects.all(), many=False)
 
     class Meta:
         model = Schedule

--- a/calendars/serializers.py
+++ b/calendars/serializers.py
@@ -31,7 +31,7 @@ class CalendarDetailSerializer(s.ModelSerializer):
         title = data.get("title")
         if self.Meta.model.objects.filter(user=user, title=title).exists():
             raise s.ValidationError(
-                {"title": f"해당 유저에 타이틀 '{title}'이 이미 존재합니다."}
+                {"title": f"해당 유저에 타이틀 '{title}'이/가 이미 존재합니다."}
             )
 
         return data

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -109,6 +109,19 @@ class TestScheduleList(TestAuthBase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["title"], self.schedule.title)
 
+    def test_create_schedule_without_memo(self):
+        payload = {
+            "calendar": self.calendar.pk,
+            "title": "schedule1",
+            "start_date": "9999-12-31",
+        }
+        response = self.client.post(self.URL, data=payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.content
+        )
+        for key in payload.keys():
+            self.assertIn(key, response.data)
+
 
 class TestScheduleDetail(TestAuthBase):
     pass

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -85,3 +85,30 @@ class TestCalendarDetail(TestAuthBase):
         response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Calendar.objects.filter(id=self.calendar.id).exists())
+
+
+class TestScheduleList(TestAuthBase):
+    URL = "/api/v1/calendars/schedule/"
+
+    def setUp(self):
+        super().setUp()
+
+        # create sample **_set
+        self.memo_set = MemoSet.objects.create(title="memo_set", user=self.user)
+        self.calendar = Calendar.objects.create(title="calendar", user=self.user)
+        self.todo_set = TodoSet.objects.create(title="todo_set", user=self.user)
+
+        # create sample schedule
+        self.schedule = Schedule.objects.create(
+            calendar=self.calendar, title="scheudle", start_date=datetime(2024, 12, 12)
+        )
+
+    def test_get_sample_schedule(self):
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], self.schedule.title)
+
+
+class TestScheduleDetail(TestAuthBase):
+    pass

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -110,11 +110,11 @@ class TestScheduleList(TestAuthBase):
 
     def test_get_sample_schedule(self):
         response = self.client.get(
-            self.URL, query_params={"start_date": self.schedule.start_date}
+            self.URL, query_params={"start_date": self.schedule1.start_date}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["title"], self.schedule.title)
+        self.assertEqual(response.data[0]["title"], self.schedule1.title)
 
     def test_create_schedule_without_memo(self):
         payload = {
@@ -195,19 +195,21 @@ class TestScheduleListPagination(TestAuthBase):
         self.url = reverse("schedule-list")
 
     def test_get_schedules_with_pagination(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 1, "page_size": 10})
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "page": 1}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 10)
 
     def test_get_schedules_with_pagination_second_page(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 2, "page_size": 10})
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "page": 2}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 5)
 
     def test_get_schedules_with_pagination_invalid_page(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 3, "page_size": 10})
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "page": 3}
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_get_schedules_with_pagination_invalid_page_size(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 1, "page_size": 100})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -35,6 +35,13 @@ class TestCalendarList(TestAuthBase):
         response = self.client.post(self.URL, data=payload)
         
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Calendar.objects.count(), 1)
+    
+    def test_create_calendar_duplicated(self):
+        payload = {"title": "Calendar1"} # sample calendar와 동일한 이름
+        response = self.client.post(self.URL, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Calendar.objects.count(), 1)
 
 
 class TestCalendarDetail(TestAuthBase):

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-from rest_framework import reverse, status
+from datetime import datetime, timedelta
+from rest_framework import status
 from rest_framework.authentication import get_user_model
+from rest_framework.reverse import reverse
 
 from calendars.models import Calendar, Schedule
 from memos.models import MemoSet
@@ -93,27 +94,33 @@ class TestScheduleList(TestAuthBase):
     def setUp(self):
         super().setUp()
 
-        # create sample **_set
-        self.memo_set = MemoSet.objects.create(title="memo_set", user=self.user)
-        self.calendar = Calendar.objects.create(title="calendar", user=self.user)
-        self.todo_set = TodoSet.objects.create(title="todo_set", user=self.user)
-
-        # create sample schedule
-        self.schedule = Schedule.objects.create(
-            calendar=self.calendar, title="scheudle", start_date=datetime(2024, 12, 12)
+        self.calendar1 = Calendar.objects.create(user=self.user, title="Work")
+        self.calendar2 = Calendar.objects.create(user=self.user, title="Personal")
+        self.schedule1 = Schedule.objects.create(
+            calendar=self.calendar1,
+            start_date=datetime.now(),
+            end_date=datetime.now() + timedelta(hours=1),
+            title="Meeting",
         )
+        self.schedule2 = Schedule.objects.create(
+            calendar=self.calendar2,
+            start_date=datetime.now() + timedelta(days=1),
+            end_date=datetime.now() + timedelta(days=1, hours=1),
+            title="Gym",
+        )
+        self.url = reverse("schedule-list")
 
     def test_get_sample_schedule(self):
         response = self.client.get(
             self.URL, query_params={"start_date": self.schedule.start_date}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["title"], self.schedule.title)
 
     def test_create_schedule_without_memo(self):
         payload = {
-            "calendar": self.calendar.pk,
+            "calendar": self.calendar1.pk,
             "title": "schedule1",
             "start_date": "9999-12-31",
         }
@@ -123,6 +130,47 @@ class TestScheduleList(TestAuthBase):
         )
         for key in payload.keys():
             self.assertIn(key, response.data)
+
+    def test_get_without_start_date(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_with_start_date(self):
+        response = self.client.get(self.url, {"start_date": datetime.now().isoformat()})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_get_with_start_date_and_calendar(self):
+        response = self.client.get(
+            self.url,
+            {
+                "start_date": datetime.now().isoformat(),
+                "calendar[]": [self.calendar1.title],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_get_with_start_date_and_view_monthly(self):
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "view": "monthly"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_get_with_start_date_and_view_weekly(self):
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "view": "weekly"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_get_with_start_date_and_view_daily(self):
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "view": "daily"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
 
 
 class TestScheduleDetail(TestAuthBase):

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -104,7 +104,9 @@ class TestScheduleList(TestAuthBase):
         )
 
     def test_get_sample_schedule(self):
-        response = self.client.get(self.URL)
+        response = self.client.get(
+            self.URL, query_params={"start_date": self.schedule.start_date}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["title"], self.schedule.title)

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -1,8 +1,11 @@
+from datetime import datetime
 from rest_framework import reverse, status
 from rest_framework.authentication import get_user_model
 
-from calendars.models import Calendar
+from calendars.models import Calendar, Schedule
+from memos.models import MemoSet
 from tests.auth_base_test import TestAuthBase
+from todos.models import TodoSet
 
 
 User = get_user_model()
@@ -33,19 +36,19 @@ class TestCalendarList(TestAuthBase):
     def test_create_calendar_invalid(self):
         payload = {}  # 타이틀 누락
         response = self.client.post(self.URL, data=payload)
-        
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Calendar.objects.count(), 1)
-    
+
     def test_create_calendar_duplicated(self):
-        payload = {"title": "Calendar1"} # sample calendar와 동일한 이름
+        payload = {"title": "Calendar1"}  # sample calendar와 동일한 이름
         response = self.client.post(self.URL, data=payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Calendar.objects.count(), 1)
 
 
 class TestCalendarDetail(TestAuthBase):
-    URL = "/api/v1/calendars/"
+    URL = "/api/v1/calendars/name/"
 
     def setUp(self):
         super().setUp()

--- a/calendars/urls.py
+++ b/calendars/urls.py
@@ -11,7 +11,7 @@ from .views import (
 
 calendar_urls = [
     path(
-        "<str:calendar_name>/",
+        "name/<str:calendar_name>/",
         CalendarDetailView.as_view(),
         name="calendar-detail",
     ),

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from django.core.exceptions import BadRequest, ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import NotFound, ValidationError
@@ -234,7 +234,7 @@ class ScheduleListView(ListAPIView):
     def post(self, request):
         serializer = self.serializer_class(data=request.data)
         if not serializer.is_valid():
-            raise BadRequest(serializer.errors)
+            raise ValidationError(serializer.errors)
 
         serializer.save()
 

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -1,5 +1,4 @@
-from datetime import date, datetime
-from xml.dom import ValidationErr
+from datetime import date, datetime, timedelta
 
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -16,7 +15,6 @@ from calendars.models import Calendar, Schedule
 from .serializers import (
     CalendarDetailSerializer,
     ScheduleDetailSerializer,
-    ScheduleDirectionChoices,
     ScheduleViewChoices,
     ScheduleUpdateSerializer,
 )
@@ -204,7 +202,7 @@ class ScheduleListView(ListAPIView):
 
         # `start_date` 필터링
         if not param.get("start_date"):
-            raise ValidationErr("start_date is required")
+            raise ValidationError("start_date is required")
         start_date = datetime.fromisoformat(param["start_date"])
         queryset = queryset.filter(start_date__gte=start_date)
 
@@ -222,11 +220,11 @@ class ScheduleListView(ListAPIView):
                     )
                 case "weekly":
                     queryset = queryset.filter(
-                        start_date__lt=start_date + datetime.timedelta(days=7)
+                        start_date__lt=start_date + timedelta(days=7)
                     )
                 case "daily":
                     queryset = queryset.filter(
-                        start_date__lt=start_date + datetime.timedelta(days=1)
+                        start_date__lt=start_date + timedelta(days=1)
                     )
 
         # `page`, `page_size` 필터링은 PageNumberPagination 사용

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -14,6 +14,8 @@ from calendars.models import Calendar, Schedule
 from .serializers import (
     CalendarDetailSerializer,
     ScheduleDetailSerializer,
+    ScheduleDirectionChoices,
+    ScheduleViewChoices,
     ScheduleUpdateSerializer,
 )
 
@@ -164,7 +166,23 @@ class ScheduleListView(ListAPIView):
                 type=date,
             ),
             OpenApiParameter(
-                name="end_date", description="조회 종료 날짜", required=True, type=date
+                name="view",
+                description="뷰 타입으로, 일간(daily), 주간(weekly) 혹은 월간(monthly)으로 세팅합니다. 기본값은 월간입니다.",
+                required=False,
+                type=ScheduleViewChoices,
+            ),
+            OpenApiParameter(
+                name="page",
+                description="페이지 번호를 입력합니다. 1부터 세며, 기본값은 1입니다. 0보다 큰 정수를 허용합니다.",
+                required=False,
+                type=int,
+                default=1,
+            ),
+            OpenApiParameter(
+                name="direction",
+                description="페이지 조회시 순방향(next) 혹은 역방향(previous으로 이동하는 옵션입니다. 기본값은 next 입니다.",
+                required=False,
+                type=ScheduleDirectionChoices,
             ),
             OpenApiParameter(
                 name="calendar",
@@ -177,8 +195,34 @@ class ScheduleListView(ListAPIView):
         tags=["Schedules"],
     )
     def get(self, request):
-        # Placeholder implementation
-        return Response({"message": "List of schedules"}, status=status.HTTP_200_OK)
+        user = request.user
+        queryset = self.queryset.filter(calendar__user_id=user.id)
+
+        param = request.query_params
+
+        if param.get("start_date"):
+            # !TODO
+            pass
+
+        if param.get("calendar"):
+            # !TODO
+            pass
+
+        if param.get("view"):
+            # !TODO
+            pass
+
+        if param.get("page"):
+            # !TODO
+            pass
+
+        if param.get("direction"):
+            # !TODO
+            pass
+
+        serializer = self.serializer_class(instance=queryset, many=True)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         summary="일정 등록",

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -1,5 +1,4 @@
-from datetime import date
-import datetime
+from datetime import date, datetime
 from xml.dom import ValidationErr
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -206,7 +205,7 @@ class ScheduleListView(ListAPIView):
         # `start_date` 필터링
         if not param.get("start_date"):
             raise ValidationErr("start_date is required")
-        start_date = datetime.datetime(param.get("start_date"))
+        start_date = datetime.fromisoformat(param["start_date"])
         queryset = queryset.filter(start_date__gte=start_date)
 
         # `calendar[]` 필터링

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -54,7 +54,7 @@ class CalendarListView(APIView):
         )
         if not serializer.is_valid():
             return Response(
-                {"message": "Invalid Request 💀"}, status=status.HTTP_400_BAD_REQUEST
+                serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
         serializer.save(user=request.user)

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -201,8 +201,7 @@ class ScheduleListView(ListAPIView):
         param = request.query_params
 
         if param.get("start_date"):
-            # !TODO
-            pass
+            queryset = queryset.filter(start_date__gte=param.get("start_date"))
 
         if param.get("calendar"):
             # !TODO

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -178,13 +178,6 @@ class ScheduleListView(ListAPIView):
                 default=1,
             ),
             OpenApiParameter(
-                name="page_size",
-                description="페이지당 표시되는 항목 수를 입력합니다. 기본값은 30입니다. 1부터 100까지의 정수를 허용합니다.",
-                required=False,
-                type=int,
-                default=30,
-            ),
-            OpenApiParameter(
                 name="calendar[]",
                 description="캘린더 필터링, 다중인자를 허용합니다.",
                 required=False,
@@ -227,7 +220,8 @@ class ScheduleListView(ListAPIView):
                         start_date__lt=start_date + timedelta(days=1)
                     )
 
-        # `page`, `page_size` 필터링은 PageNumberPagination 사용
+        # `page` 필터링
+        queryset = self.pagination_class().paginate_queryset(queryset, request, view=self)
 
         serializer = self.serializer_class(instance=queryset, many=True)
 

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -185,8 +185,8 @@ class ScheduleListView(ListAPIView):
                 type=ScheduleDirectionChoices,
             ),
             OpenApiParameter(
-                name="calendar",
-                description="캘린더 필터링, ','를 기준으로 분리.",
+                name="calendar[]",
+                description="캘린더 필터링, 다중인자를 허용합니다.",
                 required=False,
                 type=str,
             ),
@@ -203,9 +203,10 @@ class ScheduleListView(ListAPIView):
         if param.get("start_date"):
             queryset = queryset.filter(start_date__gte=param.get("start_date"))
 
-        if param.get("calendar"):
-            # !TODO
-            pass
+        # `calendar[]` 필터링
+        if param.get("calendar[]") is not None:
+            calendars = set(param.getlist("calendar[]"))
+            queryset = queryset.filter(calendar__title__in=calendars)
 
         if param.get("view"):
             # !TODO

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -7,6 +7,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -154,6 +155,7 @@ class ScheduleListView(ListAPIView):
     permission_classes = [IsAuthenticated]
     serializer_class = ScheduleDetailSerializer
     queryset = Schedule.objects.select_related("calendar")
+    pagination_class = PageNumberPagination
 
     @extend_schema(
         summary="일정 조회",
@@ -179,10 +181,11 @@ class ScheduleListView(ListAPIView):
                 default=1,
             ),
             OpenApiParameter(
-                name="direction",
-                description="페이지 조회시 순방향(next) 혹은 역방향(previous으로 이동하는 옵션입니다. 기본값은 next 입니다.",
+                name="page_size",
+                description="페이지당 표시되는 항목 수를 입력합니다. 기본값은 30입니다. 1부터 100까지의 정수를 허용합니다.",
                 required=False,
-                type=ScheduleDirectionChoices,
+                type=int,
+                default=30,
             ),
             OpenApiParameter(
                 name="calendar[]",
@@ -227,13 +230,7 @@ class ScheduleListView(ListAPIView):
                         start_date__lt=start_date + datetime.timedelta(days=1)
                     )
 
-        if param.get("page"):
-            # !TODO
-            pass
-
-        if param.get("direction"):
-            # !TODO
-            pass
+        # `page`, `page_size` 필터링은 PageNumberPagination 사용
 
         serializer = self.serializer_class(instance=queryset, many=True)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -157,6 +157,8 @@ REST_FRAMEWORK = {
         "rest_framework.parsers.MultiPartParser",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,  # 페이지당 표시되는 항목 수
 }
 
 # for more settings, see https://drf-spectacular.readthedocs.io/en/latest/settings.html


### PR DESCRIPTION
## 변경 내용
이 PR에서는 캘린더 및 일정 관리 기능을 개선하고 새로운 기능을 추가합니다. 주요 변경 사항은 다음과 같습니다:

1. **시리얼라이저 개선**  
   - `MemoDetailSerializer`와 `ChoiceField`를 사용하여 일정(`Schedule`) 관련 시리얼라이저를 확장.
   - `ScheduleViewChoices`, `ScheduleDirectionChoices` 시리얼라이저를 추가하여, `GET` 요청의 `query_params`에 대한 명시적 Choice 기반 검증 추가.

2. **새로운 기능**  
   - 일정 목록 보기(`ScheduleListView`)에 일간, 주간, 월간 보기와 필터링 기능 추가.
   - 일정 조회 API에 페이지네이션 기능 통합(`PageNumberPagination`).

3. **테스트 강화**  
   - 새롭게 추가된 일정 목록 보기 및 필터링 관련 기능을 검증하는 유닛 테스트 추가.
   - 중복 캘린더 생성 방지 및 일정 생성 검증 로직 테스트 추가.

4. **URL 경로 수정**  
   - 캘린더 상세보기 URL 구조를 `/api/v1/calendars/name/<str:calendar_name>/`으로 변경.

5. **기타 코드 개선**  
   - `ValidationError` 반환 시 더 명확한 에러 메시지 제공.
   - `ScheduleListView`에서 불필요한 코드를 제거하고, 가독성을 높임.

---

## 테스트된 시나리오
1. 일정 목록 조회 (일간/주간/월간 보기 필터링 및 페이지네이션 적용).
2. 잘못된 입력값에 대한 유효성 검증.
3. 캘린더 중복 생성 방지 확인.
4. 유효한 일정 생성 요청에 대한 처리 확인.

---

## 변경 이유
- 기존 일정 목록 조회 기능이 제한적이었고, 페이지네이션이 없어 대량의 데이터를 처리하기 어려웠습니다.
- 클라이언트 요청에 따라 일정 조회 API의 사용자 경험을 개선하고, 캘린더 데이터의 정확성과 보안을 강화하기 위해 필요했습니다.

---

## 주의 사항
- 프론트엔드에서 `view`, `calendar[]`, `start_date`와 같은 `query_params`의 사용 방식이 변경될 수 있으므로 관련 문서를 업데이트해야 합니다.
- 기존 데이터베이스와의 호환성을 위해 신규 API 호출 시 주의가 필요합니다.