### PR TITLE
feat: schedule copy view with tests

### DIFF
--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -196,23 +196,17 @@ class TestScheduleListPagination(TestAuthBase):
         self.url = reverse("schedule-list")
 
     def test_get_schedules_with_pagination(self):
-        response = self.client.get(
-            self.url, {"start_date": datetime.now().isoformat(), "page": 1}
-        )
+        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 1})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 10)
 
     def test_get_schedules_with_pagination_second_page(self):
-        response = self.client.get(
-            self.url, {"start_date": datetime.now().isoformat(), "page": 2}
-        )
+        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 2})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 5)
 
     def test_get_schedules_with_pagination_invalid_page(self):
-        response = self.client.get(
-            self.url, {"start_date": datetime.now().isoformat(), "page": 3}
-        )
+        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 3})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
@@ -253,3 +247,16 @@ class TestCopySchedule(TestAuthBase):
         response = self.client.post(non_existent_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("message", response.data)
+
+    def test_copy_schedule_with_no_memo(self):
+        """create a schedule with no memo and copy it"""
+        schedule = Schedule.objects.create(
+            calendar=self.calendar,
+            start_date=datetime.now().date(),
+            end_date=datetime.now().date() + timedelta(days=1),
+            title="Original Schedule",
+        )
+        copy_url = f"{self.URL}{schedule.pk}/copy/"
+        response = self.client.post(copy_url)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Schedule.objects.last().memo, None)

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import date, datetime, timedelta
 
+from django.conf.locale import de
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
@@ -154,13 +155,15 @@ class ScheduleCopyView(APIView):
 
             # Copy instance
             instance.pk = None
-            instance.memo.pk = None
+            if instance.memo:
+                instance.memo.pk = None
+                new_memo = deepcopy(instance.memo)
+                new_memo.save()
+            else:
+                new_memo = None
 
-            new_memo: Memo = deepcopy(instance.memo)
             new_schedule = deepcopy(instance)
             new_schedule.memo = new_memo
-
-            new_memo.save()
             new_schedule.save()
 
             serializer = self.serializer_class(instance=new_schedule)

--- a/calendars/views.py
+++ b/calendars/views.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import date, datetime, timedelta
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -11,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from calendars.models import Calendar, Schedule
+from memos.models import Memo
 
 from .serializers import (
     CalendarDetailSerializer,
@@ -134,18 +136,41 @@ class CalendarDetailView(APIView):
 
 
 class ScheduleCopyView(APIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = ScheduleDetailSerializer
+    queryset = Schedule.objects.select_related("memo")
+
     @extend_schema(
         summary="일정 복사",
-        description="schedule_id의 일정을 복사하여 새로운 일정으로 생성합니다. 이때 메모가 존재하면 메모도 함께 복사합니다.",
+        description="schedule_id의 일정을 복사하여 새로운 일정으로 생성합니다. 이때 메모가 존재하면 메모도 함께 복사합니다."
+        + "복사된 일정은 기존 일정과 동일한 속성을 가지고 일정의 시작일, 시작시간 모두 기존 일정과 동일하게 생성됩니다."
+        + "따라서, 복사된 일정의 시간을 변경하려면 일정 수정 API를 호출해야 합니다.",
         responses={201: ScheduleDetailSerializer},
         tags=["Schedules"],
     )
     def post(self, request, schedule_id):
-        # Placeholder implementation
-        return Response(
-            {"message": f"Copied schedule {schedule_id}"},
-            status=status.HTTP_201_CREATED,
-        )
+        try:
+            instance = self.queryset.get(pk=schedule_id)
+
+            # Copy instance
+            instance.pk = None
+            instance.memo.pk = None
+
+            new_memo: Memo = deepcopy(instance.memo)
+            new_schedule = deepcopy(instance)
+            new_schedule.memo = new_memo
+
+            new_memo.save()
+            new_schedule.save()
+
+            serializer = self.serializer_class(instance=new_schedule)
+
+            return Response(
+                data=serializer.data,
+                status=status.HTTP_201_CREATED,
+            )
+        except ObjectDoesNotExist as exc:
+            raise NotFound(detail={"message": "일정이 존재하지 않습니다."}) from exc
 
 
 class ScheduleListView(ListAPIView):


### PR DESCRIPTION
## 변경사항
1. **일정 복사 API 구현**
   - `ScheduleCopyView`에 POST 메서드 추가하여 일정 복사 기능을 구현.
   - 기존 일정과 동일한 속성으로 새로운 일정을 생성하며, 메모가 존재하는 경우 메모도 함께 복사.
   - 복사된 일정의 시작일, 시작시간은 기존 일정과 동일하며, 변경이 필요할 경우 일정 수정 API를 호출해야 함.
   - 요청이 실패하는 경우 적절한 오류 메시지를 반환.

2. **테스트 코드 추가**
   - `TestCopySchedule` 클래스 추가:
     - 일정 복사 성공 케이스 테스트.
     - 존재하지 않는 일정 복사 시 실패 케이스 테스트.

3. **모델 관계 확장**
   - `memos.models`의 `Memo`와 `MemoSet` 모델을 테스트 환경에서 활용.

## 상세 구현
- **뷰 로직**
  - 기존 일정을 조회 후, `deepcopy`를 활용하여 일정 및 메모를 복사.
  - 복사된 메모와 일정은 각각 새로운 인스턴스로 데이터베이스에 저장.
  - 저장된 일정 데이터를 `ScheduleDetailSerializer`로 직렬화하여 반환.

- **테스트**
  - `copy()` 엔드포인트 호출 후 복사된 일정과 메모의 필드 값 및 ID가 기존과 달라야 함을 검증.
  - 존재하지 않는 ID로 호출 시 404 상태 코드와 메시지를 확인.

## 참고
- 클라이언트는 복사된 일정의 시작일 또는 시간을 변경하려면 일정 수정 API를 호출해야 합니다.
- 스키마 문서(`extend_schema`)에서 관련 설명을 추가하여 명확히 전달.