### PR TITLE
fix: test코드에서 schedule POST 요청에 calendar.pk 를 넣어 실패하는 테스트 고침

### DIFF
--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -118,7 +118,7 @@ class TestScheduleList(TestAuthBase):
 
     def test_create_schedule_without_memo(self):
         payload = {
-            "calendar": self.calendar1.pk,
+            "calendar": self.calendar1.title,
             "title": "schedule1",
             "start_date": "9999-12-31",
         }


### PR DESCRIPTION
Correct the test by using the calendar title instead of the primary key for the schedule POST request.