### PR TITLE
Feat: PLANA-166 Schedule Search

### DIFF
--- a/calendars/serializers.py
+++ b/calendars/serializers.py
@@ -8,6 +8,7 @@ from rest_framework.fields import ChoiceField
 from calendars.models import Calendar, Schedule
 from memos.models import Memo
 from memos.serializers import MemoDetailSerializer
+from tags.models import Tag
 
 User = get_user_model()
 
@@ -50,6 +51,12 @@ class ScheduleDetailSerializer(s.ModelSerializer):
     calendar = s.SlugRelatedField(
         slug_field="title",
         queryset=Calendar.objects.all(),
+        required=False,
+    )
+    schedule_tags = s.SlugRelatedField(
+        slug_field="title",
+        queryset=Tag.objects.all(),
+        many=True,
         required=False,
     )
 

--- a/calendars/serializers.py
+++ b/calendars/serializers.py
@@ -70,10 +70,11 @@ class ScheduleDetailSerializer(s.ModelSerializer):
         user = request.user
         memo = validated_data.pop("memo", None)
         cal = validated_data.pop("calendar", None)
+        tags = validated_data.pop("schedule_tags", None)
 
         if cal is None:
             # calendar 미포함시 기본 캘린더를 사용합니다.
-            default_cal = Calendar.objects.get(user_id=user.pk, title="Calendar"),
+            default_cal = (Calendar.objects.get(user_id=user.pk, title="Calendar"),)
             cal = default_cal[0]
 
         instance = Schedule.objects.create(
@@ -82,8 +83,11 @@ class ScheduleDetailSerializer(s.ModelSerializer):
             **validated_data,
         )
 
+        instance.schedule_tags.set(tags)
+        instance.save()
+
         return instance
-    
+
     def update(self, instance: Schedule, validated_data):
         """
         Schedule을 업데이트합니다.

--- a/calendars/tests.py
+++ b/calendars/tests.py
@@ -3,9 +3,10 @@ from rest_framework import status
 from rest_framework.authentication import get_user_model
 from rest_framework.reverse import reverse
 
+from tests.auth_base_test import TestAuthBase
 from calendars.models import Calendar, Schedule
 from memos.models import Memo, MemoSet
-from tests.auth_base_test import TestAuthBase
+from tags.models import Tag
 
 
 User = get_user_model()
@@ -184,7 +185,7 @@ class TestScheduleDetail(TestAuthBase):
             calendar=self.calendar,
             title="Test Schedule",
             start_date=datetime.now(),
-            end_date=datetime.now() + timedelta(hours=1)
+            end_date=datetime.now() + timedelta(hours=1),
         )
         self.url = f"{self.URL}{self.schedule.pk}/"
 
@@ -219,17 +220,23 @@ class TestScheduleListPagination(TestAuthBase):
         self.url = reverse("schedule-list")
 
     def test_get_schedules_with_pagination(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 1})
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "page": 1}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 10)
 
     def test_get_schedules_with_pagination_second_page(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 2})
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "page": 2}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 5)
 
     def test_get_schedules_with_pagination_invalid_page(self):
-        response = self.client.get(self.url, {"start_date": datetime.now().isoformat(), "page": 3})
+        response = self.client.get(
+            self.url, {"start_date": datetime.now().isoformat(), "page": 3}
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
@@ -283,3 +290,110 @@ class TestCopySchedule(TestAuthBase):
         response = self.client.post(copy_url)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Schedule.objects.last().memo, None)
+
+
+class TestScheduleSearch(TestAuthBase):
+    URL = "/api/v1/calendars/schedule/search/"
+
+    def setUp(self):
+        super().setUp()
+
+        # Create calendar
+        self.calendar = Calendar.objects.create(user=self.user, title="Test Calendar")
+
+        # Create memo sets and memos
+        self.memo_set = MemoSet.objects.create(user=self.user, title="Test MemoSet")
+        self.memo1 = Memo.objects.create(
+            memo_set=self.memo_set, text="Meeting notes about project"
+        )
+        self.memo2 = Memo.objects.create(
+            memo_set=self.memo_set, text="점심 약속"
+        )  # Korean: Lunch appointment
+        self.memo3 = Memo.objects.create(
+            memo_set=self.memo_set, text="Regular status update"
+        )
+
+        # Create tags
+        self.tag1 = Tag.objects.create(title="work", user=self.user)
+        self.tag2 = Tag.objects.create(title="personal", user=self.user)
+        self.tag3 = Tag.objects.create(title="important", user=self.user)
+
+        # Create schedules with various combinations
+        self.schedule1 = Schedule.objects.create(
+            calendar=self.calendar,
+            title="Team Meeting",
+            start_date=datetime.now(),
+            end_date=datetime.now() + timedelta(hours=1),
+            memo=self.memo1,
+        )
+        self.schedule1.schedule_tags.add(self.tag1, self.tag3)
+
+        self.schedule2 = Schedule.objects.create(
+            calendar=self.calendar,
+            title="점심 미팅",  # Korean: Lunch meeting
+            start_date=datetime.now() + timedelta(days=1),
+            end_date=datetime.now() + timedelta(days=1, hours=1),
+            memo=self.memo2,
+        )
+        self.schedule2.schedule_tags.add(self.tag2)
+
+        self.schedule3 = Schedule.objects.create(
+            calendar=self.calendar,
+            title="Status Update",
+            start_date=datetime.now() + timedelta(days=2),
+            end_date=datetime.now() + timedelta(days=2, hours=1),
+            memo=self.memo3,
+        )
+        self.schedule3.schedule_tags.add(self.tag1)
+
+    def test_search_by_english_title(self):
+        response = self.client.get(f"{self.URL}?query=meeting")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "Team Meeting")
+
+    def test_search_by_korean_title(self):
+        response = self.client.get(f"{self.URL}?query=점심")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "점심 미팅")
+
+    def test_search_by_memo_text(self):
+        response = self.client.get(f"{self.URL}?query=project")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(
+            response.data[0]["memo"]["text"], "Meeting notes about project"
+        )
+
+    def test_search_by_korean_memo_text(self):
+        response = self.client.get(f"{self.URL}?query=약속")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["memo"]["text"], "점심 약속")
+
+    def test_search_with_tag_filter(self):
+        response = self.client.get(f"{self.URL}?tag[]={self.tag1.title}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        titles = {schedule["title"] for schedule in response.data}
+        self.assertEqual(titles, {"Team Meeting", "Status Update"})
+
+    def test_search_with_multiple_tags(self):
+        response = self.client.get(
+            f"{self.URL}?tag[]={self.tag1.title}&tag[]={self.tag3.title}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "Team Meeting")
+
+    def test_search_with_query_and_tag(self):
+        response = self.client.get(f"{self.URL}?query=meeting&tag[]={self.tag1.title}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "Team Meeting")
+
+    def test_search_no_results(self):
+        response = self.client.get(f"{self.URL}?query=nonexistent")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)


### PR DESCRIPTION
## 일정 검색 및 태그, 메모 관련 기능 추가

### 내용

#### 변경 사항
1. **일정 검색 기능 구현**
   - `ScheduleSearchView` 클래스 추가
   - 제목 및 메모 내용으로 일정 검색 가능
   - 다중 태그 필터링 기능 지원 (`tag[]` 파라미터)

2. **태그 기능 추가**
   - `Schedule` 모델에 태그 필드 추가 (`schedule_tags`)
   - Serializer에 `SlugRelatedField`로 태그 처리 구현
   - 새 일정 생성 시 태그 설정 가능

3. **메모 생성 로직 개선**
   - 일정 생성 시 메모(`Memo`)를 함께 생성하도록 로직 추가
   - 기본 `MemoSet` 지정 가능

4. **테스트 케이스 추가**
   - 일정 생성 시 메모 및 태그를 포함하는 테스트 작성
   - 검색 및 태그 필터링 테스트 추가

#### 기타 수정
- 테스트 에러를 해결하기 위한 import 정리
- 코드 스타일 및 가독성 개선

#### 관련 티켓
- [PLANA-166](https://plana-noh-choi.atlassian.net/browse/PLANA-166)

#### 테스트 상태
- [x] 유닛 테스트 통과
- [x] 새로운 테스트 케이스 추가 및 검증 완료

### 주의사항
- [Elastic](https://www.elastic.co) 도입을 위한 Vector Database 리서치 필요

---

[PLANA-166]: https://plana-noh-choi.atlassian.net/browse/PLANA-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ